### PR TITLE
chore: update github links and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 NCSU Security Applications & Technologies
+Copyright (c) 2017 North Carolina State University Security Applications & Technologies
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ncsu-sat/popover.git"
+    "url": "git+https://github.com/ncstate-sat/popover.git"
   },
   "bugs": {
-    "url": "https://github.com/ncsu-sat/popover/issues"
+    "url": "https://github.com/ncstate-sat/popover/issues"
   },
-  "homepage": "https://github.com/ncsu-sat/popover#readme",
+  "homepage": "https://github.com/ncstate-sat/popover#readme",
   "devDependencies": {
     "@angular/animations": "~4.4.4",
     "@angular/cdk": "2.0.0-beta.12",

--- a/src/demo/styles.scss
+++ b/src/demo/styles.scss
@@ -1,14 +1,14 @@
 @import '~@angular/material/theming';
 
 // Material theming
-$ncsu-primary: mat-palette($mat-red, 700);
-$ncsu-accent:  mat-palette($mat-blue-grey);
-$ncsu-warn:    mat-palette($mat-deep-orange);
+$ncstate-primary: mat-palette($mat-red, 700);
+$ncstate-accent:  mat-palette($mat-blue-grey);
+$ncstate-warn:    mat-palette($mat-deep-orange);
 
-$ncsu-theme: mat-light-theme($ncsu-primary, $ncsu-accent, $ncsu-warn);
+$ncstate-theme: mat-light-theme($ncstate-primary, $ncstate-accent, $ncstate-warn);
 
 @include mat-core();
-@include angular-material-theme($ncsu-theme);
+@include angular-material-theme($ncstate-theme);
 
 html, body {
   height: 100%;


### PR DESCRIPTION
Going to switch the packaging format to `@ncstate/sat-popover` in a followup.