### PR TITLE
Document importance of anchor/popover order

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Wrap any component you want to display in a popover with an `<sat-popover>` comp
 
 Next, hook the popover to an anchor element.
 
+> **Note** Be sure to place the element with the `satPopoverAnchorFor` directive before the `sat-popover` component.
+
 ```html
 <button [satPopoverAnchorFor]="contactPopover" (click)="contactPopover.toggle()">
   See Contact Details


### PR DESCRIPTION
If the `satPopoverAnchorFor` is placed after the `sat-popover` element, the `_notifications` property on the component will not be initialized in time, causing the component to throw.

This PR simply documents that the order of elements matters.