### PR TITLE
feat: add `start` and `end` as possible positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,21 +83,17 @@ By default, the popover will appear centered over the button. If you instead wan
 to appear below the anchor:
 
 ```html
-<sat-popover #contactPopover yPosition="below" [overlapAnchor]="false">
+<sat-popover #contactPopover yPosition="below">
   <!-- ... -->
 </sat-popover>
 ```
 
 You can use the following to position the popover around the anchor:
 
-| Input         | Type                            | Default  |
-|---------------|---------------------------------|----------|
-| xPosition     | 'before' \| 'center' \| 'after' | 'center' |
-| yPosition     | 'above' \| 'center' \| 'below'  | 'center' |
-| overlapAnchor | boolean                         | true     |
-
-> Note: When `xPosition` and `yPosition` are both `'center'`, `overlapAnchor` will have no
-effect.
+| Input         | Type                                                | Default  |
+|---------------|-----------------------------------------------------|----------|
+| xPosition     | 'before' \| 'start' \| 'center' \| 'end' \| 'after' | 'center' |
+| yPosition     | 'above'  \| 'start' \| 'center' \| 'end' \| 'below' | 'center' |
 
 ### Opening and closing
 

--- a/src/demo/app/action-api/action-api.component.ts
+++ b/src/demo/app/action-api/action-api.component.ts
@@ -8,7 +8,7 @@ import { Component } from '@angular/core';
       <mat-card-title>Action API</mat-card-title>
       <mat-card-content>
         <div class="avatar" #a="satPopoverAnchor" [satPopoverAnchorFor]="p">W</div>
-        <sat-popover #p xPosition="after" overlapAnchor="false">
+        <sat-popover #p xPosition="after">
           <div class="info mat-caption">
             <div class="caret"></div>
             <div>Messages: 12</div>

--- a/src/demo/app/focus/focus.component.ts
+++ b/src/demo/app/focus/focus.component.ts
@@ -18,7 +18,7 @@ import { SatPopover } from '@ncstate/sat-popover';
           <p><b>Birth Date</b>: {{ form.value.birthDate | date }}</p>
         </div>
 
-        <sat-popover #p hasBackdrop xPosition="after" overlapAnchor="false">
+        <sat-popover #p hasBackdrop xPosition="after">
           <div class="form" [formGroup]="form">
             <mat-form-field>
               <input matInput (keydown)="closeOnEnter($event)"

--- a/src/demo/app/positioning/positioning.component.ts
+++ b/src/demo/app/positioning/positioning.component.ts
@@ -12,7 +12,9 @@ import { Component } from '@angular/core';
           <mat-form-field>
             <mat-select [(ngModel)]="xPos" placeholder="xPosition">
               <mat-option value="before">Before</mat-option>
+              <mat-option value="start">Start</mat-option>
               <mat-option value="center">Center</mat-option>
+              <mat-option value="end">End</mat-option>
               <mat-option value="after">After</mat-option>
               <mat-option value="octopus">Octopus</mat-option>
             </mat-select>
@@ -21,7 +23,9 @@ import { Component } from '@angular/core';
           <mat-form-field>
             <mat-select [(ngModel)]="yPos" placeholder="yPosition">
               <mat-option value="above">Above</mat-option>
+              <mat-option value="start">Start</mat-option>
               <mat-option value="center">Center</mat-option>
+              <mat-option value="end">End</mat-option>
               <mat-option value="below">Below</mat-option>
               <mat-option value="aardvark">Aardvark</mat-option>
             </mat-select>
@@ -32,8 +36,6 @@ import { Component } from '@angular/core';
               [(ngModel)]="margin"
               placeholder="anchor's margin-left (px)">
           </mat-form-field>
-
-          <mat-checkbox [(ngModel)]="overlap">Overlap Trigger</mat-checkbox>
         </div>
 
         <button mat-raised-button
@@ -49,8 +51,7 @@ import { Component } from '@angular/core';
       <sat-popover #p
           [xPosition]="xPos"
           [yPosition]="yPos"
-          hasBackdrop
-          [overlapAnchor]="overlap">
+          hasBackdrop>
         <div class="popover mat-body-2">
           Nifty
         </div>
@@ -63,7 +64,6 @@ export class PositioningDemo {
 
   xPos = 'after';
   yPos = 'center';
-  overlap = false;
   margin = 0;
 
 }

--- a/src/demo/app/scroll-strategies/scroll-strategies.component.ts
+++ b/src/demo/app/scroll-strategies/scroll-strategies.component.ts
@@ -23,9 +23,7 @@ import { Component } from '@angular/core';
           TOGGLE
         </button>
 
-        <sat-popover #p xPosition="after" hasBackdrop
-            [overlapAnchor]="false"
-            [scrollStrategy]="strategy">
+        <sat-popover #p xPosition="after" hasBackdrop [scrollStrategy]="strategy">
           <div class="popover mat-body-1">Scroll the page to observe behavior.</div>
         </sat-popover>
 

--- a/src/demo/app/tooltip/tooltip.component.ts
+++ b/src/demo/app/tooltip/tooltip.component.ts
@@ -21,7 +21,7 @@ import 'rxjs/add/observable/of';
           Hover Me (instant)
         </div>
 
-        <sat-popover #instant xPosition="after" [overlapAnchor]="false">
+        <sat-popover #instant xPosition="after">
           <div class="tooltip-wrapper mat-body-1">
             Multi-line <br>
             <span class="seagreen">Tooltip</span>
@@ -35,7 +35,7 @@ import 'rxjs/add/observable/of';
           Hover Me (1000ms delay)
         </div>
 
-        <sat-popover #delayed xPosition="after" [overlapAnchor]="false">
+        <sat-popover #delayed xPosition="after">
           <div class="tooltip-wrapper mat-body-1">
             A tooltip that's slow to open
           </div>

--- a/src/demo/app/transitions/transitions.component.ts
+++ b/src/demo/app/transitions/transitions.component.ts
@@ -16,7 +16,7 @@ import { Component } from '@angular/core';
           </mat-form-field>
         </div>
         <div class="anchor" [satPopoverAnchorFor]="p" (click)="p.toggle()"></div>
-        <sat-popover #p xPosition="after" yPosition="below" overlapAnchor="false"
+        <sat-popover #p xPosition="after" yPosition="below"
             [openTransition]="openTransition"
             [closeTransition]="closeTransition">
           <div class="popover mat-subtitle">Hello!</div>

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -293,12 +293,17 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
       ['above', 'start', 'center', 'end', 'below'] :
       ['above', 'below'];
 
-    // Add fallbacks for each allowed prioritized fallback position combo
-    prioritizeAroundTarget(xTarget, possibleXPositions).forEach(xPosition => {
-      prioritizeAroundTarget(yTarget, possibleYPositions).forEach(yPosition => {
-        this._addFallback(strategy, xPosition, yPosition);
+    // Create fallbacks for each allowed prioritized fallback position combo
+    const fallbacks = [];
+    prioritizeAroundTarget(xTarget, possibleXPositions).forEach(xPos => {
+      prioritizeAroundTarget(yTarget, possibleYPositions).forEach(yPos => {
+        fallbacks.push({xPos, yPos});
       });
     });
+
+    // Remove the first fallback since it will be the target position that is already applied
+    fallbacks.slice(1, fallbacks.length)
+      .forEach(({xPos, yPos}) => this._addFallback(strategy, xPos, yPos));
   }
 
   /** Convert a specific x and y position into a fallback and apply it to the strategy. */

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -303,11 +303,11 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
 
     // Remove the first fallback since it will be the target position that is already applied
     fallbacks.slice(1, fallbacks.length)
-      .forEach(({xPos, yPos}) => this._addFallback(strategy, xPos, yPos));
+      .forEach(({xPos, yPos}) => this._applyFallback(strategy, xPos, yPos));
   }
 
   /** Convert a specific x and y position into a fallback and apply it to the strategy. */
-  private _addFallback(strategy, xPos, yPos): void {
+  private _applyFallback(strategy, xPos, yPos): void {
     const {originX, overlayX} = getHorizontalConnectionPosPair(xPos);
     const {originY, overlayY} = getVerticalConnectionPosPair(yPos);
     strategy.withFallbackPosition({originX, originY}, {overlayX, overlayY});
@@ -349,7 +349,7 @@ function getVerticalConnectionPosPair(y: SatPopoverPositionY):
   }
 }
 
-/** Helper function an overlay connection position to equivalent popover position. */
+/** Helper function to convert an overlay connection position to equivalent popover position. */
 function getHorizontalPopoverPosition(x: HorizontalConnectionPos): SatPopoverPositionX {
   if (x === 'start') {
     return 'after';
@@ -362,7 +362,7 @@ function getHorizontalPopoverPosition(x: HorizontalConnectionPos): SatPopoverPos
   return 'center';
 }
 
-/** Helper function an overlay connection position to equivalent popover position. */
+/** Helper function to convert an overlay connection position to equivalent popover position. */
 function getVerticalPopoverPosition(y: VerticalConnectionPos): SatPopoverPositionY {
   if (y === 'top') {
     return 'below';
@@ -389,24 +389,24 @@ function prioritizeAroundTarget<T>(target: T, options: T[]): T[] {
   // Set the first item to be the target
   const reordered = [target];
 
-  // Make leftSide and rightSide of the target stacks where the highest priority item is last
-  const leftSide = options.slice(0, targetIndex);
-  const rightSide = options.slice(targetIndex + 1, options.length).reverse();
+  // Make left and right stacks where the highest priority item is last
+  const left = options.slice(0, targetIndex);
+  const right = options.slice(targetIndex + 1, options.length).reverse();
 
   // Alternate between stacks until one is empty
-  while (leftSide.length && rightSide.length) {
-    reordered.push(rightSide.pop());
-    reordered.push(leftSide.pop());
+  while (left.length && right.length) {
+    reordered.push(right.pop());
+    reordered.push(left.pop());
   }
 
   // Flush out right side
-  while (rightSide.length) {
-    reordered.push(rightSide.pop());
+  while (right.length) {
+    reordered.push(right.pop());
   }
 
   // Flush out left side
-  while (leftSide.length) {
-    reordered.push(leftSide.pop());
+  while (left.length) {
+    reordered.push(left.pop());
   }
 
   return reordered;

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -263,11 +263,31 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
 
   /** Create and return a position strategy based on config provided to the component instance. */
   private _getPosition(): ConnectedPositionStrategy {
-    // Get config values from the popover
-    const overlap = this.attachedPopover.overlapAnchor;
 
-    const xPos = this.attachedPopover.xPosition;
-    const yPos = this.attachedPopover.yPosition;
+    let overlap = false;
+    let xPos: SatPopoverPositionX;
+    let yPos: SatPopoverPositionY;
+
+    // Get config values from the popover
+    if (this.attachedPopover.xPosition === 'start') {
+      overlap = true;
+      xPos = 'after';
+    } else if (this.attachedPopover.xPosition === 'end') {
+      overlap = true;
+      xPos = 'before';
+    } else {
+      xPos = this.attachedPopover.xPosition;
+    }
+
+    if (this.attachedPopover.yPosition === 'start') {
+      overlap = true;
+      yPos = 'below';
+    } else if (this.attachedPopover.yPosition === 'end') {
+      overlap = true;
+      yPos = 'above';
+    } else {
+      yPos = this.attachedPopover.yPosition;
+    }
 
     // Convert position to value usable by strategy. Invert for the overlay so that 'above' means
     // the overlay is attached at the 'bottom'

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -31,13 +31,13 @@ import {
   getInvalidScrollStrategyError,
 } from './popover.errors';
 
-export type SatPopoverPositionX = 'before' | 'center' | 'after';
-export type SatPopoverPositionY = 'above'  | 'center' | 'below';
+export type SatPopoverPositionX = 'before' | 'start' | 'center' | 'end' | 'after';
+export type SatPopoverPositionY = 'above'  | 'start' | 'center' | 'end' | 'below';
 // TODO: support close on resolution of https://github.com/angular/material2/issues/7922
 export type SatPopoverScrollStrategy = 'noop' | 'block' | 'reposition';
 
-export const VALID_POSX: SatPopoverPositionX[] = ['before', 'center', 'after'];
-export const VALID_POSY: SatPopoverPositionY[] = ['above', 'center', 'below'];
+export const VALID_POSX: SatPopoverPositionX[] = ['before', 'start', 'center', 'end', 'after'];
+export const VALID_POSY: SatPopoverPositionY[] = ['above', 'start', 'center', 'end', 'below'];
 export const VALID_SCROLL: SatPopoverScrollStrategy[] = ['noop', 'block', 'reposition'];
 
 // See http://cubic-bezier.com/#.25,.8,.25,1 for reference.
@@ -77,18 +77,6 @@ export class SatPopover implements AfterViewInit {
     }
   }
   private _yPosition: SatPopoverPositionY = 'center';
-
-  /** Whether the popover should overlap its anchor. */
-  @Input()
-  get overlapAnchor() { return this._overlapAnchor; }
-  set overlapAnchor(val: boolean) {
-    const coerced = coerceBooleanProperty(val);
-    if (this._overlapAnchor !== coerced) {
-      this._overlapAnchor = coerced;
-      this._dispatchNotification(new PopoverNotification(NotificationAction.REPOSITION));
-    }
-  }
-  private _overlapAnchor = true;
 
   /** How the popover should handle scrolling. */
   @Input()
@@ -220,11 +208,11 @@ export class SatPopover implements AfterViewInit {
 
   /** Apply positioning classes based on positioning inputs. */
   _setPositionClasses(posX = this.xPosition, posY = this.yPosition) {
-    this._classList['sat-popover-before'] = posX === 'before';
-    this._classList['sat-popover-after']  = posX === 'after';
+    this._classList['sat-popover-before'] = ['before', 'end'].includes(posX);
+    this._classList['sat-popover-after']  = ['after', 'start'].includes(posX);
 
-    this._classList['sat-popover-above'] = posY === 'above';
-    this._classList['sat-popover-below'] = posY === 'below';
+    this._classList['sat-popover-above'] = ['above', 'end'].includes(posY);
+    this._classList['sat-popover-below'] = ['below', 'start'].includes(posY);
 
     this._classList['sat-popover-center'] = posX === 'center' || posY === 'center';
   }

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -208,11 +208,11 @@ export class SatPopover implements AfterViewInit {
 
   /** Apply positioning classes based on positioning inputs. */
   _setPositionClasses(posX = this.xPosition, posY = this.yPosition) {
-    this._classList['sat-popover-before'] = ['before', 'end'].includes(posX);
-    this._classList['sat-popover-after']  = ['after', 'start'].includes(posX);
+    this._classList['sat-popover-before'] = posX === 'before' || posX === 'end';
+    this._classList['sat-popover-after']  = posX === 'after' || posX === 'start';
 
-    this._classList['sat-popover-above'] = ['above', 'end'].includes(posY);
-    this._classList['sat-popover-below'] = ['below', 'start'].includes(posY);
+    this._classList['sat-popover-above'] = posY === 'above' || posY === 'end';
+    this._classList['sat-popover-below'] = posY === 'below' || posY === 'start';
 
     this._classList['sat-popover-center'] = posX === 'center' || posY === 'center';
   }

--- a/src/lib/popover/popover.spec.ts
+++ b/src/lib/popover/popover.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   OverlayContainer,
+  ConnectedPositionStrategy,
   RepositionScrollStrategy,
   BlockScrollStrategy,
 } from '@angular/cdk/overlay';
@@ -429,6 +430,46 @@ describe('SatPopover', () => {
       const overlayAfterSecondOpen = comp.anchor._overlayRef;
 
       expect(overlayAfterFirstOpen === overlayAfterSecondOpen).toBe(false);
+    }));
+
+    it('should generate the correct number of positions', fakeAsync(() => {
+      let strategy;
+      let overlayConfig;
+      fixture.detectChanges();
+
+      // centered over anchor can be any of 5 x 5 positions
+      comp.popover.open();
+      overlayConfig = comp.anchor._overlayRef.getConfig();
+      strategy = overlayConfig.positionStrategy as ConnectedPositionStrategy;
+      expect(strategy.positions.length).toBe(25, 'overlapping');
+
+      comp.popover.close();
+      fixture.detectChanges();
+      tick();
+
+      // non-overlapping can be any of 2 x 2 positions
+      comp.xPos = 'after';
+      comp.yPos = 'below';
+      fixture.detectChanges();
+
+      comp.popover.open();
+      overlayConfig = comp.anchor._overlayRef.getConfig();
+      strategy = overlayConfig.positionStrategy as ConnectedPositionStrategy;
+      expect(strategy.positions.length).toBe(4, 'non-overlapping');
+
+      comp.popover.close();
+      fixture.detectChanges();
+      tick();
+
+      // overlapping in one direction can be any of 2 x 5 positions
+      comp.xPos = 'start';
+      comp.yPos = 'below';
+      fixture.detectChanges();
+
+      comp.popover.open();
+      overlayConfig = comp.anchor._overlayRef.getConfig();
+      strategy = overlayConfig.positionStrategy as ConnectedPositionStrategy;
+      expect(strategy.positions.length).toBe(10, 'overlapping in one dimension');
     }));
 
     it('should throw an error when an invalid xPosition is provided', () => {

--- a/src/lib/popover/popover.spec.ts
+++ b/src/lib/popover/popover.spec.ts
@@ -630,7 +630,7 @@ export class KeyboardPopoverTestComponent {
   template: `
     <div id="anchor" [satPopoverAnchorFor]="p">Anchor</div>
 
-    <sat-popover #p [xPosition]="xPos" [yPosition]="yPos" [overlapAnchor]="overlap">
+    <sat-popover #p [xPosition]="xPos" [yPosition]="yPos">
       <div id="content">Popover</div>
     </sat-popover>
   `
@@ -640,7 +640,6 @@ export class PositioningTestComponent {
   @ViewChild(SatPopover) popover: SatPopover;
   xPos = 'center';
   yPos = 'center';
-  overlap = true;
 }
 
 /** This component is for testing scroll behavior. */


### PR DESCRIPTION
Fixes #68 
Fixes #72

* Adds `start` and `end` to `xPosition` and `yPosition` options
* Improves the fallback iterations to progressively emanate from the target position


BREAKING CHANGES

This removes `overlapAnchor` as a positioning option.
  * If before you were using `xPosition="before" overlapAnchor="true"`, you should now use, `xPosition="start"`.
  * If you were using `xPosition="after" overlapAnchor="false"`, you can now just use `xPosition="after"`.

