### PR TITLE
chore: rename xPosition/yPosition to horizontalAlign/verticalAlign

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,23 +77,26 @@ Next, hook the popover to an anchor element.
 
 > Note: `hasBackdrop` is explained below
 
-### Positioning
+### Alignment
 
-By default, the popover will appear centered over the button. If you instead want the popover
+By default, the popover will appear centered over the anchor. If you instead want the popover
 to appear below the anchor:
 
 ```html
-<sat-popover #contactPopover yPosition="below">
+<sat-popover #contactPopover verticalAlign="below">
   <!-- ... -->
 </sat-popover>
 ```
 
-You can use the following to position the popover around the anchor:
+You can use the following to align the popover around the anchor:
 
-| Input         | Type                                                | Default  |
-|---------------|-----------------------------------------------------|----------|
-| xPosition     | 'before' \| 'start' \| 'center' \| 'end' \| 'after' | 'center' |
-| yPosition     | 'above'  \| 'start' \| 'center' \| 'end' \| 'below' | 'center' |
+| Input             | Type                                                | Default  |
+|-------------------|-----------------------------------------------------|----------|
+| `horizontalAlign` | 'before' \| 'start' \| 'center' \| 'end' \| 'after' | 'center' |
+| `verticalAlign`   | 'above'  \| 'start' \| 'center' \| 'end' \| 'below' | 'center' |
+
+For convenience, you can also use `xAlign` and `yAlign` as shorthand for `horizontalAlign`
+and `verticalAlign`, respectively.
 
 ### Opening and closing
 

--- a/src/demo/app/action-api/action-api.component.ts
+++ b/src/demo/app/action-api/action-api.component.ts
@@ -8,7 +8,7 @@ import { Component } from '@angular/core';
       <mat-card-title>Action API</mat-card-title>
       <mat-card-content>
         <div class="avatar" #a="satPopoverAnchor" [satPopoverAnchorFor]="p">W</div>
-        <sat-popover #p xPosition="after">
+        <sat-popover #p horizontalAlign="after">
           <div class="info mat-caption">
             <div class="caret"></div>
             <div>Messages: 12</div>

--- a/src/demo/app/focus/focus.component.ts
+++ b/src/demo/app/focus/focus.component.ts
@@ -18,7 +18,7 @@ import { SatPopover } from '@ncstate/sat-popover';
           <p><b>Birth Date</b>: {{ form.value.birthDate | date }}</p>
         </div>
 
-        <sat-popover #p hasBackdrop xPosition="after">
+        <sat-popover #p hasBackdrop horizontalAlign="after">
           <div class="form" [formGroup]="form">
             <mat-form-field>
               <input matInput (keydown)="closeOnEnter($event)"

--- a/src/demo/app/positioning/positioning.component.ts
+++ b/src/demo/app/positioning/positioning.component.ts
@@ -10,7 +10,7 @@ import { Component } from '@angular/core';
 
         <div class="config">
           <mat-form-field>
-            <mat-select [(ngModel)]="xPos" placeholder="xPosition">
+            <mat-select [(ngModel)]="horizontalAlign" placeholder="horizontalAlign">
               <mat-option value="before">Before</mat-option>
               <mat-option value="start">Start</mat-option>
               <mat-option value="center">Center</mat-option>
@@ -21,7 +21,7 @@ import { Component } from '@angular/core';
           </mat-form-field>
 
           <mat-form-field>
-            <mat-select [(ngModel)]="yPos" placeholder="yPosition">
+            <mat-select [(ngModel)]="verticalAlign" placeholder="verticalAlign">
               <mat-option value="above">Above</mat-option>
               <mat-option value="start">Start</mat-option>
               <mat-option value="center">Center</mat-option>
@@ -48,10 +48,9 @@ import { Component } from '@angular/core';
 
       </mat-card-content>
 
-      <sat-popover #p
-          [xPosition]="xPos"
-          [yPosition]="yPos"
-          hasBackdrop>
+      <sat-popover #p hasBackdrop
+          [horizontalAlign]="horizontalAlign"
+          [verticalAlign]="verticalAlign">
         <div class="popover mat-body-2">
           Nifty
         </div>
@@ -62,8 +61,8 @@ import { Component } from '@angular/core';
 })
 export class PositioningDemo {
 
-  xPos = 'after';
-  yPos = 'center';
+  horizontalAlign = 'after';
+  verticalAlign = 'center';
   margin = 0;
 
 }

--- a/src/demo/app/scroll-strategies/scroll-strategies.component.ts
+++ b/src/demo/app/scroll-strategies/scroll-strategies.component.ts
@@ -23,7 +23,7 @@ import { Component } from '@angular/core';
           TOGGLE
         </button>
 
-        <sat-popover #p xPosition="after" hasBackdrop [scrollStrategy]="strategy">
+        <sat-popover #p horizontalAlign="after" hasBackdrop [scrollStrategy]="strategy">
           <div class="popover mat-body-1">Scroll the page to observe behavior.</div>
         </sat-popover>
 

--- a/src/demo/app/tooltip/tooltip.component.ts
+++ b/src/demo/app/tooltip/tooltip.component.ts
@@ -21,7 +21,7 @@ import 'rxjs/add/observable/of';
           Hover Me (instant)
         </div>
 
-        <sat-popover #instant xPosition="after">
+        <sat-popover #instant horizontalAlign="after">
           <div class="tooltip-wrapper mat-body-1">
             Multi-line <br>
             <span class="seagreen">Tooltip</span>
@@ -35,7 +35,7 @@ import 'rxjs/add/observable/of';
           Hover Me (1000ms delay)
         </div>
 
-        <sat-popover #delayed xPosition="after">
+        <sat-popover #delayed horizontalAlign="after">
           <div class="tooltip-wrapper mat-body-1">
             A tooltip that's slow to open
           </div>

--- a/src/demo/app/transitions/transitions.component.ts
+++ b/src/demo/app/transitions/transitions.component.ts
@@ -16,7 +16,7 @@ import { Component } from '@angular/core';
           </mat-form-field>
         </div>
         <div class="anchor" [satPopoverAnchorFor]="p" (click)="p.toggle()"></div>
-        <sat-popover #p xPosition="after" yPosition="below"
+        <sat-popover #p xAlign="after" yAlign="below"
             [openTransition]="openTransition"
             [closeTransition]="closeTransition">
           <div class="popover mat-subtitle">Hello!</div>

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -264,21 +264,18 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
 
   /** Create and return a position strategy based on config provided to the component instance. */
   private _getPositionStrategy(): ConnectedPositionStrategy {
+    const horizontalTarget = this.attachedPopover.horizontalAlign;
+    const verticalTarget = this.attachedPopover.verticalAlign;
+
     // Attach the overlay at the preferred position
-    const {originX, overlayX} =
-        getHorizontalConnectionPosPair(this.attachedPopover.horizontalAlign);
-    const {originY, overlayY} =
-        getVerticalConnectionPosPair(this.attachedPopover.verticalAlign);
+    const {originX, overlayX} = getHorizontalConnectionPosPair(horizontalTarget);
+    const {originY, overlayY} = getVerticalConnectionPosPair(verticalTarget);
     const strategy = this._overlay.position()
       .connectedTo(this._elementRef, {originX, originY}, {overlayX, overlayY})
       .withDirection(this._getDirection());
 
     // Add fallbacks based on the preferred positions
-    this._addFallbacks(
-      strategy,
-      this.attachedPopover.horizontalAlign,
-      this.attachedPopover.verticalAlign
-    );
+    this._addFallbacks(strategy, horizontalTarget, verticalTarget);
 
     return strategy;
   }

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -26,19 +26,21 @@ import {
 } from './notification.service';
 import {
   getUnanchoredPopoverError,
-  getInvalidXPositionError,
-  getInvalidYPositionError,
+  getInvalidHorizontalAlignError,
+  getInvalidVerticalAlignError,
   getInvalidScrollStrategyError,
 } from './popover.errors';
 
-export type SatPopoverPositionX = 'before' | 'start' | 'center' | 'end' | 'after';
-export type SatPopoverPositionY = 'above'  | 'start' | 'center' | 'end' | 'below';
 // TODO: support close on resolution of https://github.com/angular/material2/issues/7922
 export type SatPopoverScrollStrategy = 'noop' | 'block' | 'reposition';
+export type SatPopoverHorizontalAlign = 'before' | 'start' | 'center' | 'end' | 'after';
+export type SatPopoverVerticalAlign = 'above'  | 'start' | 'center' | 'end' | 'below';
 
-export const VALID_POSX: SatPopoverPositionX[] = ['before', 'start', 'center', 'end', 'after'];
-export const VALID_POSY: SatPopoverPositionY[] = ['above', 'start', 'center', 'end', 'below'];
 export const VALID_SCROLL: SatPopoverScrollStrategy[] = ['noop', 'block', 'reposition'];
+export const VALID_HORIZ_ALIGN: SatPopoverHorizontalAlign[] =
+    ['before', 'start', 'center', 'end', 'after'];
+export const VALID_VERT_ALIGN: SatPopoverVerticalAlign[] =
+    ['above', 'start', 'center', 'end', 'below'];
 
 // See http://cubic-bezier.com/#.25,.8,.25,1 for reference.
 const DEFAULT_TRANSITION  = '200ms cubic-bezier(0.25, 0.8, 0.25, 1)';
@@ -52,31 +54,31 @@ const DEFAULT_TRANSITION  = '200ms cubic-bezier(0.25, 0.8, 0.25, 1)';
 })
 export class SatPopover implements AfterViewInit {
 
-  /** Position of the popover on the x axis. */
+  /** Alignment of the popover on the horizontal axis. */
   @Input()
-  get xPosition() { return this._xPosition; }
-  set xPosition(val: SatPopoverPositionX) {
-    this._validateXPosition(val);
-    if (this._xPosition !== val) {
-      this._xPosition = val;
-      this._setPositionClasses();
+  get horizontalAlign() { return this._horizontalAlign; }
+  set horizontalAlign(val: SatPopoverHorizontalAlign) {
+    this._validateHorizontalAlign(val);
+    if (this._horizontalAlign !== val) {
+      this._horizontalAlign = val;
+      this._setAlignmentClasses();
       this._dispatchConfigNotification(new PopoverNotification(NotificationAction.REPOSITION));
     }
   }
-  private _xPosition: SatPopoverPositionX = 'center';
+  private _horizontalAlign: SatPopoverHorizontalAlign = 'center';
 
-  /** Position of the popover on the y axis. */
+  /** Alignment of the popover on the vertical axis. */
   @Input()
-  get yPosition() { return this._yPosition; }
-  set yPosition(val: SatPopoverPositionY) {
-    this._validateYPosition(val);
-    if (this._yPosition !== val) {
-      this._yPosition = val;
-      this._setPositionClasses();
+  get verticalAlign() { return this._verticalAlign; }
+  set verticalAlign(val: SatPopoverVerticalAlign) {
+    this._validateVerticalAlign(val);
+    if (this._verticalAlign !== val) {
+      this._verticalAlign = val;
+      this._setAlignmentClasses();
       this._dispatchConfigNotification(new PopoverNotification(NotificationAction.REPOSITION));
     }
   }
-  private _yPosition: SatPopoverPositionY = 'center';
+  private _verticalAlign: SatPopoverVerticalAlign = 'center';
 
   /** How the popover should handle scrolling. */
   @Input()
@@ -155,7 +157,7 @@ export class SatPopover implements AfterViewInit {
   ) { }
 
   ngAfterViewInit() {
-    this._setPositionClasses();
+    this._setAlignmentClasses();
   }
 
   /** Open this popover. */
@@ -206,15 +208,15 @@ export class SatPopover implements AfterViewInit {
     }
   }
 
-  /** Apply positioning classes based on positioning inputs. */
-  _setPositionClasses(posX = this.xPosition, posY = this.yPosition) {
-    this._classList['sat-popover-before'] = posX === 'before' || posX === 'end';
-    this._classList['sat-popover-after']  = posX === 'after' || posX === 'start';
+  /** Apply alignment classes based on alignment inputs. */
+  _setAlignmentClasses(horizAlign = this.horizontalAlign, vertAlign = this.verticalAlign) {
+    this._classList['sat-popover-before'] = horizAlign === 'before' || horizAlign === 'end';
+    this._classList['sat-popover-after']  = horizAlign === 'after' || horizAlign === 'start';
 
-    this._classList['sat-popover-above'] = posY === 'above' || posY === 'end';
-    this._classList['sat-popover-below'] = posY === 'below' || posY === 'start';
+    this._classList['sat-popover-above'] = vertAlign === 'above' || vertAlign === 'end';
+    this._classList['sat-popover-below'] = vertAlign === 'below' || vertAlign === 'start';
 
-    this._classList['sat-popover-center'] = posX === 'center' || posY === 'center';
+    this._classList['sat-popover-center'] = horizAlign === 'center' || vertAlign === 'center';
   }
 
   /** Move the focus inside the focus trap and remember where to return later. */
@@ -273,17 +275,17 @@ export class SatPopover implements AfterViewInit {
     this._notifications.dispatch(notification);
   }
 
-  /** Throws an error if the position is not a valid xPosition. */
-  private _validateXPosition(pos: SatPopoverPositionX): void {
-    if (VALID_POSX.indexOf(pos) === -1) {
-      throw getInvalidXPositionError(pos);
+  /** Throws an error if the alignment is not a valid horizontalAlign. */
+  private _validateHorizontalAlign(pos: SatPopoverHorizontalAlign): void {
+    if (VALID_HORIZ_ALIGN.indexOf(pos) === -1) {
+      throw getInvalidHorizontalAlignError(pos);
     }
   }
 
-  /** Throws an error if the position is not a valid yPosition. */
-  private _validateYPosition(pos: SatPopoverPositionY): void {
-    if (VALID_POSY.indexOf(pos) === -1) {
-      throw getInvalidYPositionError(pos);
+  /** Throws an error if the alignment is not a valid verticalAlign. */
+  private _validateVerticalAlign(pos: SatPopoverVerticalAlign): void {
+    if (VALID_VERT_ALIGN.indexOf(pos) === -1) {
+      throw getInvalidVerticalAlignError(pos);
     }
   }
 

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -67,6 +67,11 @@ export class SatPopover implements AfterViewInit {
   }
   private _horizontalAlign: SatPopoverHorizontalAlign = 'center';
 
+  /** Alignment of the popover on the x axis. Alias for `horizontalAlign`. */
+  @Input()
+  get xAlign() { return this.horizontalAlign; }
+  set xAlign(val: SatPopoverHorizontalAlign) { this.horizontalAlign = val; }
+
   /** Alignment of the popover on the vertical axis. */
   @Input()
   get verticalAlign() { return this._verticalAlign; }
@@ -79,6 +84,11 @@ export class SatPopover implements AfterViewInit {
     }
   }
   private _verticalAlign: SatPopoverVerticalAlign = 'center';
+
+  /** Alignment of the popover on the y axis. Alias for `verticalAlign`. */
+  @Input()
+  get yAlign() { return this.verticalAlign; }
+  set yAlign(val: SatPopoverVerticalAlign) { this.verticalAlign = val; }
 
   /** How the popover should handle scrolling. */
   @Input()

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -1,5 +1,4 @@
 import {
-  AfterViewInit,
   Component,
   ElementRef,
   EventEmitter,
@@ -52,7 +51,7 @@ const DEFAULT_TRANSITION  = '200ms cubic-bezier(0.25, 0.8, 0.25, 1)';
   styleUrls: ['./popover.component.scss'],
   templateUrl: './popover.component.html',
 })
-export class SatPopover implements AfterViewInit {
+export class SatPopover {
 
   /** Alignment of the popover on the horizontal axis. */
   @Input()
@@ -61,7 +60,6 @@ export class SatPopover implements AfterViewInit {
     this._validateHorizontalAlign(val);
     if (this._horizontalAlign !== val) {
       this._horizontalAlign = val;
-      this._setAlignmentClasses();
       this._dispatchConfigNotification(new PopoverNotification(NotificationAction.REPOSITION));
     }
   }
@@ -79,7 +77,6 @@ export class SatPopover implements AfterViewInit {
     this._validateVerticalAlign(val);
     if (this._verticalAlign !== val) {
       this._verticalAlign = val;
-      this._setAlignmentClasses();
       this._dispatchConfigNotification(new PopoverNotification(NotificationAction.REPOSITION));
     }
   }
@@ -165,10 +162,6 @@ export class SatPopover implements AfterViewInit {
     private _focusTrapFactory: FocusTrapFactory,
     @Optional() @Inject(DOCUMENT) private _document: any
   ) { }
-
-  ngAfterViewInit() {
-    this._setAlignmentClasses();
-  }
 
   /** Open this popover. */
   open(): void {

--- a/src/lib/popover/popover.errors.ts
+++ b/src/lib/popover/popover.errors.ts
@@ -9,11 +9,11 @@ export function getUnanchoredPopoverError(): Error {
 }
 
 export function getInvalidHorizontalAlignError(alignment): Error {
-  return Error(generateGenericError('horizontalAlign', alignment, VALID_HORIZ_ALIGN));
+  return Error(generateGenericError('horizontalAlign/xAlign', alignment, VALID_HORIZ_ALIGN));
 }
 
 export function getInvalidVerticalAlignError(alignment): Error {
-  return Error(generateGenericError('verticalAlign', alignment, VALID_VERT_ALIGN));
+  return Error(generateGenericError('verticalAlign/yAlign', alignment, VALID_VERT_ALIGN));
 }
 
 export function getInvalidScrollStrategyError(strategy): Error {

--- a/src/lib/popover/popover.errors.ts
+++ b/src/lib/popover/popover.errors.ts
@@ -1,4 +1,4 @@
-import { VALID_POSX, VALID_POSY, VALID_SCROLL } from './popover.component';
+import { VALID_HORIZ_ALIGN, VALID_VERT_ALIGN, VALID_SCROLL } from './popover.component';
 
 export function getInvalidPopoverError(): Error {
   return Error('SatPopoverAnchor must be provided an SatPopover component instance.');
@@ -8,12 +8,12 @@ export function getUnanchoredPopoverError(): Error {
   return Error('SatPopover is not anchored to any SatPopoverAnchor.');
 }
 
-export function getInvalidXPositionError(pos): Error {
-  return Error(generateGenericError('xPosition', pos, VALID_POSX));
+export function getInvalidHorizontalAlignError(alignment): Error {
+  return Error(generateGenericError('horizontalAlign', alignment, VALID_HORIZ_ALIGN));
 }
 
-export function getInvalidYPositionError(pos): Error {
-  return Error(generateGenericError('yPosition', pos, VALID_POSY));
+export function getInvalidVerticalAlignError(alignment): Error {
+  return Error(generateGenericError('verticalAlign', alignment, VALID_VERT_ALIGN));
 }
 
 export function getInvalidScrollStrategyError(strategy): Error {

--- a/src/lib/popover/popover.spec.ts
+++ b/src/lib/popover/popover.spec.ts
@@ -378,7 +378,7 @@ describe('SatPopover', () => {
           SatPopoverModule,
           NoopAnimationsModule,
         ],
-        declarations: [PositioningTestComponent],
+        declarations: [PositioningTestComponent, PositioningAliasTestComponent],
         providers: [
           {provide: OverlayContainer, useFactory: overlayContainerFactory}
         ]
@@ -497,6 +497,19 @@ describe('SatPopover', () => {
       expect(() => {
         fixture.detectChanges();
       }).toThrow(getInvalidVerticalAlignError('banana'));
+    });
+
+    it('should allow aliases for horizontal and vertical align inputs', () => {
+      const aliasFixture = TestBed.createComponent(PositioningAliasTestComponent);
+      const aliasComp = aliasFixture.componentInstance;
+
+      aliasComp.xAlign = 'before';
+      aliasComp.yAlign = 'end';
+
+      aliasFixture.detectChanges();
+
+      expect(aliasComp.popover.horizontalAlign).toBe('before');
+      expect(aliasComp.popover.verticalAlign).toBe('end');
     });
 
   });
@@ -686,6 +699,23 @@ export class PositioningTestComponent {
   @ViewChild(SatPopover) popover: SatPopover;
   hAlign = 'center';
   vAlign = 'center';
+}
+
+/** This component is for testing position aliases. */
+@Component({
+  template: `
+    <div id="anchor" [satPopoverAnchorFor]="p">Anchor</div>
+
+    <sat-popover #p [xAlign]="xAlign" [yAlign]="yAlign">
+      <div id="content">Popover</div>
+    </sat-popover>
+  `
+})
+export class PositioningAliasTestComponent {
+  @ViewChild(SatPopoverAnchor) anchor: SatPopoverAnchor;
+  @ViewChild(SatPopover) popover: SatPopover;
+  xAlign = 'center';
+  yAlign = 'center';
 }
 
 /** This component is for testing scroll behavior. */

--- a/src/lib/popover/popover.spec.ts
+++ b/src/lib/popover/popover.spec.ts
@@ -687,10 +687,9 @@ export class KeyboardPopoverTestComponent {
 /** This component is for testing dynamic positioning behavior. */
 @Component({
   template: `
-    <div id="anchor" [satPopoverAnchorFor]="p">Anchor</div>
-
+    <div [satPopoverAnchorFor]="p">Anchor</div>
     <sat-popover #p [horizontalAlign]="hAlign" [verticalAlign]="vAlign">
-      <div id="content">Popover</div>
+      Popover
     </sat-popover>
   `
 })
@@ -704,10 +703,9 @@ export class PositioningTestComponent {
 /** This component is for testing position aliases. */
 @Component({
   template: `
-    <div id="anchor" [satPopoverAnchorFor]="p">Anchor</div>
-
+    <div [satPopoverAnchorFor]="p">Anchor</div>
     <sat-popover #p [xAlign]="xAlign" [yAlign]="yAlign">
-      <div id="content">Popover</div>
+      Popover
     </sat-popover>
   `
 })

--- a/src/lib/popover/popover.spec.ts
+++ b/src/lib/popover/popover.spec.ts
@@ -16,8 +16,8 @@ import { SatPopoverAnchor } from './popover-anchor.directive';
 import {
   getInvalidPopoverError,
   getUnanchoredPopoverError,
-  getInvalidXPositionError,
-  getInvalidYPositionError,
+  getInvalidHorizontalAlignError,
+  getInvalidVerticalAlignError,
   getInvalidScrollStrategyError,
 } from './popover.errors';
 
@@ -407,7 +407,7 @@ describe('SatPopover', () => {
       tick();
 
       // change the position to the same thing and reopen, saving the new overlayRef
-      comp.xPos = 'center';
+      comp.hAlign = 'center';
       fixture.detectChanges();
 
       comp.popover.open();
@@ -428,7 +428,7 @@ describe('SatPopover', () => {
       tick();
 
       // change the position and reopen, saving the new overlayRef
-      comp.xPos = 'after';
+      comp.hAlign = 'after';
       fixture.detectChanges();
 
       comp.popover.open();
@@ -453,8 +453,8 @@ describe('SatPopover', () => {
       tick();
 
       // non-overlapping can be any of 2 x 2 positions
-      comp.xPos = 'after';
-      comp.yPos = 'below';
+      comp.hAlign = 'after';
+      comp.vAlign = 'below';
       fixture.detectChanges();
 
       comp.popover.open();
@@ -467,8 +467,8 @@ describe('SatPopover', () => {
       tick();
 
       // overlapping in one direction can be any of 2 x 5 positions
-      comp.xPos = 'start';
-      comp.yPos = 'below';
+      comp.hAlign = 'start';
+      comp.vAlign = 'below';
       fixture.detectChanges();
 
       comp.popover.open();
@@ -477,26 +477,26 @@ describe('SatPopover', () => {
       expect(strategy.positions.length).toBe(10, 'overlapping in one dimension');
     }));
 
-    it('should throw an error when an invalid xPosition is provided', () => {
+    it('should throw an error when an invalid horizontalAlign is provided', () => {
       fixture.detectChanges();
 
-      // set invalid xPosition
-      comp.xPos = 'kiwi';
+      // set invalid horizontalAlign
+      comp.hAlign = 'kiwi';
 
       expect(() => {
         fixture.detectChanges();
-      }).toThrow(getInvalidXPositionError('kiwi'));
+      }).toThrow(getInvalidHorizontalAlignError('kiwi'));
     });
 
-    it('should throw an error when an invalid yPosition is provided', () => {
+    it('should throw an error when an invalid verticalAlign is provided', () => {
       fixture.detectChanges();
 
-      // set invalid yPosition
-      comp.yPos = 'banana';
+      // set invalid verticalAlign
+      comp.vAlign = 'banana';
 
       expect(() => {
         fixture.detectChanges();
-      }).toThrow(getInvalidYPositionError('banana'));
+      }).toThrow(getInvalidVerticalAlignError('banana'));
     });
 
   });
@@ -612,7 +612,7 @@ class InvalidPopoverTestComponent { }
  */
 @Component({
   template: `
-    <sat-popover xPosition="after">Anchorless</sat-popover>
+    <sat-popover horizontalAlign="after">Anchorless</sat-popover>
   `
 })
 class AnchorlessPopoverTestComponent {
@@ -676,7 +676,7 @@ export class KeyboardPopoverTestComponent {
   template: `
     <div id="anchor" [satPopoverAnchorFor]="p">Anchor</div>
 
-    <sat-popover #p [xPosition]="xPos" [yPosition]="yPos">
+    <sat-popover #p [horizontalAlign]="hAlign" [verticalAlign]="vAlign">
       <div id="content">Popover</div>
     </sat-popover>
   `
@@ -684,8 +684,8 @@ export class KeyboardPopoverTestComponent {
 export class PositioningTestComponent {
   @ViewChild(SatPopoverAnchor) anchor: SatPopoverAnchor;
   @ViewChild(SatPopover) popover: SatPopover;
-  xPos = 'center';
-  yPos = 'center';
+  hAlign = 'center';
+  vAlign = 'center';
 }
 
 /** This component is for testing scroll behavior. */

--- a/src/lib/public_api.ts
+++ b/src/lib/public_api.ts
@@ -2,7 +2,7 @@ export { SatPopoverModule } from './popover/popover.module';
 export { SatPopoverAnchor } from './popover/popover-anchor.directive';
 export {
   SatPopover,
-  SatPopoverPositionX,
-  SatPopoverPositionY,
+  SatPopoverHorizontalAlign,
+  SatPopoverVerticalAlign,
   SatPopoverScrollStrategy,
 } from './popover/popover.component';


### PR DESCRIPTION
- Fixes https://github.com/ncstate-sat/popover/issues/70
- This also adds `xAlign` and `yAlign` as shorthand aliases

BREAKING CHANGE
* `xPosition` has been renamed to `horizontalAlign`
* `yPosition` has been renamed to `verticalAlign`
* `SatPopoverPositionX` has been renamed to `SatPopoverHorizontalAlign`
* `SatPopoverPositionY` has been renamed to `SatPopoverVerticalAlign`