### PR TITLE
build: make test running more friendly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Build the library into `dist/lib` and copy the library into `node_modules` for t
 to use.
 
 ```
-npm run build && npm run copylib
+npm run build
 ```
 
 ### Watching

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,12 @@ npm run watch
 
 Run karma tests
 
-> For now, ignore the warnings in between tests. They are a result of karma trying
-to run tests on build output before styles and templates are inlined.
-
 ```
 npm run test
+```
+
+To run the tests just once
+
+```
+npm run test:once
 ```

--- a/karma-test-shim.js
+++ b/karma-test-shim.js
@@ -6,7 +6,7 @@ Error.stackTraceLimit = 0; // "No stacktrace"" is us11 best for testing.
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;
 
-const libBase = '.ng_build/spec/'; // transpiled app JS and map files
+const libBase = '.ng_build/spec-ready/'; // transpiled app JS and map files
 
 // builtPaths: root paths for output ("built") files
 // get from karma.config.js, then prefix with '/base/'
@@ -40,7 +40,7 @@ System.config({
     'npm:': 'node_modules/'
   },
   // Base URL for System.js calls. 'base/' is where Karma serves files from.
-  baseURL: 'base/.ng_build/spec',
+  baseURL: 'base/.ng_build/spec-ready',
   // Extend usual application package list with test folder
   packages: {
     rxjs: { defaultExtension: 'js' },

--- a/karma-test-shim.js
+++ b/karma-test-shim.js
@@ -6,7 +6,7 @@ Error.stackTraceLimit = 0; // "No stacktrace"" is us11 best for testing.
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;
 
-const libBase = '.ng_build/spec-ready/'; // transpiled app JS and map files
+const libBase = '.ng_build/spec/'; // transpiled app JS and map files
 
 // builtPaths: root paths for output ("built") files
 // get from karma.config.js, then prefix with '/base/'
@@ -40,7 +40,7 @@ System.config({
     'npm:': 'node_modules/'
   },
   // Base URL for System.js calls. 'base/' is where Karma serves files from.
-  baseURL: 'base/.ng_build/spec-ready',
+  baseURL: 'base/.ng_build/spec',
   // Extend usual application package list with test folder
   packages: {
     rxjs: { defaultExtension: 'js' },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,7 +2,7 @@
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
 module.exports = config => {
-  const libBase = '.ng_build/spec-ready/'; // transpiled app JS and map files
+  const libBase = '.ng_build/spec/'; // transpiled app JS and map files
 
   config.set({
     basePath: '',
@@ -60,8 +60,8 @@ module.exports = config => {
     // Proxied base paths for loading assets
     proxies: {
       // required for modules fetched by SystemJS
-      '/base/.ng_build/spec-ready/node_modules/': '/base/node_modules/',
-      '/base/.ng_build/spec-ready/demo/': '/base/src/demo/'
+      '/base/.ng_build/spec/node_modules/': '/base/node_modules/',
+      '/base/.ng_build/spec/demo/': '/base/src/demo/'
     },
 
     reporters: ['progress', 'kjhtml'],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -46,6 +46,7 @@ module.exports = config => {
 
       // transpiled application & spec code paths loaded via module imports
       { pattern: libBase + '**/*.js', included: false, watched: false },
+      // Only watch a single file. All files will be changed on each update to source.
       { pattern: libBase + '**/*.spec.js', included: false, watched: true },
 
       // Asset (HTML & CSS) paths loaded via Angular's component compiler

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,7 +2,7 @@
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
 module.exports = config => {
-  const libBase = '.ng_build/spec/'; // transpiled app JS and map files
+  const libBase = '.ng_build/spec-ready/'; // transpiled app JS and map files
 
   config.set({
     basePath: '',
@@ -45,12 +45,13 @@ module.exports = config => {
       'karma-test-shim.js', // optionally extend SystemJS mapping e.g., with barrels
 
       // transpiled application & spec code paths loaded via module imports
-      { pattern: libBase + '**/*.js', included: false, watched: true },
+      { pattern: libBase + '**/*.js', included: false, watched: false },
+      { pattern: libBase + '**/*.spec.js', included: false, watched: true },
 
       // Asset (HTML & CSS) paths loaded via Angular's component compiler
       // (these paths need to be rewritten, see proxies section)
-      { pattern: libBase + '**/*.html', included: false, watched: true },
-      { pattern: libBase + '**/*.css', included: false, watched: true },
+      { pattern: libBase + '**/*.html', included: false, watched: false },
+      { pattern: libBase + '**/*.css', included: false, watched: false },
 
       // Paths for debugging with source maps in dev tools
       { pattern: libBase + '**/*.js.map', included: false, watched: false }
@@ -59,8 +60,8 @@ module.exports = config => {
     // Proxied base paths for loading assets
     proxies: {
       // required for modules fetched by SystemJS
-      '/base/.ng_build/spec/node_modules/': '/base/node_modules/',
-      '/base/.ng_build/spec/demo/': '/base/src/demo/'
+      '/base/.ng_build/spec-ready/node_modules/': '/base/node_modules/',
+      '/base/.ng_build/spec-ready/demo/': '/base/src/demo/'
     },
 
     reporters: ['progress', 'kjhtml'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1337,14 +1337,14 @@
       }
     },
     "chalk": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
-        "supports-color": "4.4.0"
+        "supports-color": "4.5.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1363,9 +1363,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -1919,7 +1919,7 @@
       "integrity": "sha512-sA2/4+/PZ/KV6CKgjrVrrUVBKCkdDO02CUlQ0YKTQoYUwPYNOtOAcWlbYhd5v/1JqYaA6oZ4sDlOU4ppVw6Wbg==",
       "dev": true,
       "requires": {
-        "chalk": "2.1.0"
+        "chalk": "2.3.0"
       }
     },
     "core-util-is": {
@@ -9661,7 +9661,7 @@
       "dev": true,
       "requires": {
         "arrify": "1.0.1",
-        "chalk": "2.1.0",
+        "chalk": "2.3.0",
         "diff": "3.3.1",
         "make-error": "1.3.0",
         "minimist": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "~6.0.60",
     "angular-cli-ghpages": "^0.5.1",
+    "chalk": "^2.3.0",
     "chokidar": "^1.7.0",
     "codelyzer": "^4.0.0",
     "concurrently": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gh-pages": "ngh --dir dist/app",
     "copylib": "bash ./scripts/copy_lib_dist.sh",
     "lint": "ng lint --type-check",
-    "test": "concurrently \"node tools/watch-test.js\" \"karma start karma.conf.js\"",
+    "test": "concurrently -r \"node tools/watch-test.js\" \"karma start karma.conf.js\"",
     "watch": "node tools/watch.js",
     "test:once": "node tools/build-test.js && karma start karma.conf.js --single-run"
   },

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "gh-pages": "ngh --dir dist/app",
     "copylib": "bash ./scripts/copy_lib_dist.sh",
     "lint": "ng lint --type-check",
-    "test": "concurrently \"npm run watch\" \"karma start karma.conf.js\"",
+    "test": "concurrently \"node tools/watch-test.js\" \"karma start karma.conf.js\"",
     "watch": "node tools/watch.js",
-    "test:once": "karma start karma.conf.js --single-run"
+    "test:once": "node tools/build-test.js && karma start karma.conf.js --single-run"
   },
   "private": true,
   "keywords": [

--- a/src/lib/tsconfig.spec.json
+++ b/src/lib/tsconfig.spec.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "outDir": "../../.ng_build/spec",
+    "outDir": "../../.ng_build/.spec-tmp",
     "target": "es5",
     "moduleResolution": "node",
     "sourceMap": true,

--- a/src/lib/tsconfig.spec.json
+++ b/src/lib/tsconfig.spec.json
@@ -6,8 +6,6 @@
     "sourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,
-    "noImplicitAny": true,
-    "suppressImplicitAnyIndexErrors": true,
     "skipLibCheck": true,
     "stripInternal": true,
     "lib": [

--- a/tools/build-test.js
+++ b/tools/build-test.js
@@ -1,0 +1,33 @@
+const { sync } = require('glob');
+const { join } = require('path');
+const { writeFileSync } = require('fs-extra');
+const sass = require('node-sass');
+
+const copyFiles = require('./utils/copy-files');
+const inlineResources = require('./utils/inline-resources');
+const spawn$ = require('./utils/rx-spawn');
+
+// Directory constants
+const BASE_DIR = process.cwd();
+const LIB_DIR = join(BASE_DIR, 'src/lib');
+const BUILD_DIR = join(BASE_DIR, '.ng_build');
+
+// Build
+spawn$('node_modules/.bin/tsc', ['-p', join(LIB_DIR, 'tsconfig.spec.json')])
+  .subscribe(undefined, undefined, () => {
+    // Copy styles and markup
+    copyFiles(LIB_DIR, '**/*.+(scss|css|html)', join(BUILD_DIR, 'spec'));
+
+    // Compile sass in build directory
+    sync(join(BUILD_DIR, 'spec', '**/*.scss')).forEach(path => {
+      const sassString = sass.renderSync({ file: path }).css.toString();
+      const newPath = path.slice(0, -4) + 'css';
+      writeFileSync(newPath, sassString, 'utf-8');
+    });
+
+    // Inline resources
+    inlineResources(BUILD_DIR, LIB_DIR);
+
+    // Copy to "ready to test" directory
+    copyFiles(join(BUILD_DIR, 'spec'), '**/*', join(BUILD_DIR, 'spec-ready'))
+  });

--- a/tools/build.js
+++ b/tools/build.js
@@ -21,8 +21,8 @@ const spawn$ = require('./utils/rx-spawn');
 // Directory constants
 const BASE_DIR = process.cwd();
 const LIB_DIR = join(BASE_DIR, 'src/lib');
-const DIST_DIR = join(BASE_DIR, 'dist/lib');
 const BUILD_DIR = join(BASE_DIR, '.ng_build');
+const DIST_DIR = join(BASE_DIR, 'dist/lib');
 
 // Map versions across packages
 const VERSIONS = {
@@ -33,9 +33,7 @@ const VERSIONS = {
 
 // Constants for running typescript commands
 const NGC = 'node_modules/.bin/ngc';
-const TSC = 'node_modules/.bin/tsc';
 const NGC_ARGS = (config) => [`-p`, join(LIB_DIR, `tsconfig.${config}.json`)];
-const TSC_ARGS = NGC_ARGS;
 
 /** Replaces the version placeholders in the specified package. */
 function replacePackageVersions(packagePath, versions) {
@@ -93,11 +91,10 @@ function buildLibrary$(globals, versions) {
     .forkJoin(
       spawn$(NGC, NGC_ARGS('lib')),
       spawn$(NGC, NGC_ARGS('es5')),
-      spawn$(TSC, TSC_ARGS('spec')),
     )
     .do(() => {
       // Copy styles and markup
-      ['es2015', 'es5', 'spec']
+      ['es2015', 'es5']
         .forEach(dir => copyFiles(LIB_DIR, '**/*.+(scss|css|html)', join(BUILD_DIR, dir)));
 
       // Compile sass in build directory
@@ -109,9 +106,6 @@ function buildLibrary$(globals, versions) {
 
       // Inline resources
       inlineResources(BUILD_DIR, LIB_DIR);
-
-      // Copy to "ready to test" directory
-      copyFiles(join(BUILD_DIR, 'spec'), '**/*', join(BUILD_DIR, 'spec-ready'))
     })
     // Rollup
     .switchMap(() => Observable.forkJoin(
@@ -139,8 +133,10 @@ function buildLibrary$(globals, versions) {
 }
 
 // Kick it off
-buildLibrary$(GLOBALS, VERSIONS).subscribe(
-  undefined,
-  err => console.error('err', err),
-  () => console.log('\ncomplete')
-);
+buildLibrary$(GLOBALS, VERSIONS)
+  .switchMap(() => Observable.forkJoin(spawn$('npm', ['run', 'copylib'])))
+  .subscribe(
+    undefined,
+    err => console.error('err', err),
+    () => console.log('\ncomplete')
+  );

--- a/tools/build.js
+++ b/tools/build.js
@@ -5,7 +5,7 @@
 const { sync } = require('glob');
 const { rollup } = require('rollup');
 const { Observable } = require('rxjs');
-const { copy, readFileSync, writeFileSync } = require('fs-extra');
+const { readFileSync, writeFileSync } = require('fs-extra');
 const { join } = require('path');
 const resolve = require('rollup-plugin-node-resolve');
 const sourcemaps = require('rollup-plugin-sourcemaps');
@@ -109,6 +109,9 @@ function buildLibrary$(globals, versions) {
 
       // Inline resources
       inlineResources(BUILD_DIR, LIB_DIR);
+
+      // Copy to "ready to test" directory
+      copyFiles(join(BUILD_DIR, 'spec'), '**/*', join(BUILD_DIR, 'spec-ready'))
     })
     // Rollup
     .switchMap(() => Observable.forkJoin(

--- a/tools/utils/rx-watch.js
+++ b/tools/utils/rx-watch.js
@@ -1,0 +1,13 @@
+const { Observable } = require('rxjs');
+const chokidar = require('chokidar');
+
+/** Watch a directory with chokidar. */
+function watch$(directory, opts) {
+  return Observable.create(observer => {
+    chokidar.watch(directory, opts)
+      .on('all', (event, path) => observer.next({ event, path }))
+      .on('error', error => observer.error(error));
+  });
+}
+
+module.exports = watch$;

--- a/tools/watch-test.js
+++ b/tools/watch-test.js
@@ -1,0 +1,22 @@
+const { Observable } = require('rxjs');
+const chokidar = require('chokidar');
+const spawn$ = require('./utils/rx-spawn');
+
+/** Watch a directory with chokidar. */
+function watch$(directory, opts) {
+  return Observable.create(observer => {
+    chokidar.watch(directory, opts)
+      .on('all', (event, path) => observer.next({ event, path }))
+      .on('error', error => observer.error(error));
+  });
+}
+
+watch$('src/lib', { usePolling: true })
+  .debounceTime(300)
+  .subscribe(() => {
+    console.log('building...');
+    // this is hacky but it gets the job done for now
+    spawn$('node', ['tools/build-test.js'])
+      .switchMap(() => spawn$('npm', ['run', 'copylib']))
+      .subscribe(undefined, undefined, () => console.log('build complete'));
+  });

--- a/tools/watch-test.js
+++ b/tools/watch-test.js
@@ -14,9 +14,8 @@ function watch$(directory, opts) {
 watch$('src/lib', { usePolling: true })
   .debounceTime(300)
   .subscribe(() => {
-    console.log('building...');
+    console.log('building for test...');
     // this is hacky but it gets the job done for now
     spawn$('node', ['tools/build-test.js'])
-      .switchMap(() => spawn$('npm', ['run', 'copylib']))
       .subscribe(undefined, undefined, () => console.log('build complete'));
   });

--- a/tools/watch.js
+++ b/tools/watch.js
@@ -10,5 +10,4 @@ watch$('src/lib', { usePolling: true })
   .debounceTime(300)
   .do(() => log('Building lib'))
   .switchMap(() => Observable.forkJoin(spawn$('node', ['tools/build.js'])))
-  .switchMap(() => Observable.forkJoin(spawn$('npm', ['run', 'copylib'])))
   .subscribe(() => log('Build complete'));


### PR DESCRIPTION
This uses separate scripts for building/watching the lib and building/watching for specs. In a not-so-elegant way, it moves the compiled spec output to a different directory after sass compilation and inlining is complete. Doing so avoids the dozens of warnings karma was throwing during the intermediate step.
