### PR TITLE
refactor: offload overlay logic from anchor directive to a service

### DIFF
--- a/src/demo/app/anchor-reuse/anchor-reuse.component.scss
+++ b/src/demo/app/anchor-reuse/anchor-reuse.component.scss
@@ -1,0 +1,6 @@
+.wrapper {
+  background: black;
+  color: white;
+  padding: 8px;
+  font-size: 16px;
+}

--- a/src/demo/app/anchor-reuse/anchor-reuse.component.ts
+++ b/src/demo/app/anchor-reuse/anchor-reuse.component.ts
@@ -16,7 +16,11 @@ import { SatPopover } from '@ncstate/sat-popover';
 
         <br>
 
-        <button mat-button
+        <mat-slide-toggle [(ngModel)]="showAnchor">Show Anchor</mat-slide-toggle>
+
+        <br>
+
+        <button mat-button *ngIf="showAnchor"
             [satPopoverAnchorFor]="getActivePopover()"
             (click)="getActivePopover().toggle()">
           Anchor
@@ -35,6 +39,7 @@ export class AnchorReuseComponent {
   @ViewChild('b') bPopover: SatPopover;
 
   activePopover = 'a';
+  showAnchor = true;
 
   getActivePopover(): SatPopover {
     return this.activePopover === 'a' ? this.aPopover : this.bPopover;

--- a/src/demo/app/anchor-reuse/anchor-reuse.component.ts
+++ b/src/demo/app/anchor-reuse/anchor-reuse.component.ts
@@ -1,0 +1,42 @@
+import { Component, ViewChild } from '@angular/core';
+import { SatPopover } from '@ncstate/sat-popover';
+
+@Component({
+  selector: 'demo-anchor-reuse',
+  styleUrls: ['anchor-reuse.component.scss'],
+  template: `
+    <mat-card>
+      <mat-card-title>Anchor Reuse</mat-card-title>
+      <mat-card-content>
+        Active Popover:
+        <mat-radio-group [(ngModel)]="activePopover">
+          <mat-radio-button value="a">A</mat-radio-button>
+          <mat-radio-button value="b">B</mat-radio-button>
+        </mat-radio-group>
+
+        <br>
+
+        <button mat-button
+            [satPopoverAnchorFor]="getActivePopover()"
+            (click)="getActivePopover().toggle()">
+          Anchor
+        </button>
+
+        <sat-popover #a xAlign="after"><div class="wrapper">A</div></sat-popover>
+        <sat-popover #b xAlign="after"><div class="wrapper">B</div></sat-popover>
+
+      </mat-card-content>
+
+    </mat-card>
+  `
+})
+export class AnchorReuseComponent {
+  @ViewChild('a') aPopover: SatPopover;
+  @ViewChild('b') bPopover: SatPopover;
+
+  activePopover = 'a';
+
+  getActivePopover(): SatPopover {
+    return this.activePopover === 'a' ? this.aPopover : this.bPopover;
+  }
+}

--- a/src/demo/app/demo.component.ts
+++ b/src/demo/app/demo.component.ts
@@ -25,6 +25,7 @@ import { Component } from '@angular/core';
       <demo-transitions></demo-transitions>
       <demo-tooltip></demo-tooltip>
       <demo-interactive-close></demo-interactive-close>
+      <demo-anchor-reuse></demo-anchor-reuse>
       <demo-speed-dial></demo-speed-dial>
     </div>
   `

--- a/src/demo/app/demo.component.ts
+++ b/src/demo/app/demo.component.ts
@@ -10,13 +10,18 @@ import { Component } from '@angular/core';
         @ncstate/sat-popover
       </a>
       <button mat-button
+          title="Toggle all content"
+          (click)="showContent = !showContent">
+        {{ showContent ? 'Hide' : 'Show' }} content
+      </button>
+      <button mat-button
           title="Toggle between RTL and LTR"
           (click)="direction = (direction == 'rtl' ? 'ltr' : 'rtl')">
         {{ direction.toUpperCase() }}
       </button>
     </mat-toolbar>
 
-    <div [dir]="direction" class="page-content">
+    <div *ngIf="showContent" [dir]="direction" class="page-content">
       <demo-positioning></demo-positioning>
       <demo-action-api></demo-action-api>
       <demo-scroll-strategies></demo-scroll-strategies>
@@ -32,4 +37,5 @@ import { Component } from '@angular/core';
 })
 export class DemoComponent {
   direction = 'ltr';
+  showContent = true;
 }

--- a/src/demo/app/demo.module.ts
+++ b/src/demo/app/demo.module.ts
@@ -13,6 +13,7 @@ import {
   MatCheckboxModule,
   MatDatepickerModule,
   MatNativeDateModule,
+  MatRadioModule,
 } from '@angular/material';
 import { BidiModule } from '@angular/cdk/bidi';
 
@@ -26,6 +27,7 @@ import { TransitionsDemo } from './transitions/transitions.component';
 import { TooltipDemo } from './tooltip/tooltip.component';
 import { SpeedDialDemo } from './speed-dial/speed-dial.component';
 import { InteractiveCloseDemo } from './interactive-close/interactive-close.component';
+import { AnchorReuseComponent } from './anchor-reuse/anchor-reuse.component';
 
 @NgModule({
   exports: [
@@ -38,6 +40,7 @@ import { InteractiveCloseDemo } from './interactive-close/interactive-close.comp
     MatCheckboxModule,
     MatDatepickerModule,
     MatNativeDateModule,
+    MatRadioModule,
     BidiModule,
   ]
 })
@@ -55,6 +58,7 @@ export class DemoMaterialModule { }
     TooltipDemo,
     SpeedDialDemo,
     InteractiveCloseDemo,
+    AnchorReuseComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/demo/app/demo.module.ts
+++ b/src/demo/app/demo.module.ts
@@ -14,6 +14,7 @@ import {
   MatDatepickerModule,
   MatNativeDateModule,
   MatRadioModule,
+  MatSlideToggleModule,
 } from '@angular/material';
 import { BidiModule } from '@angular/cdk/bidi';
 
@@ -41,6 +42,7 @@ import { AnchorReuseComponent } from './anchor-reuse/anchor-reuse.component';
     MatDatepickerModule,
     MatNativeDateModule,
     MatRadioModule,
+    MatSlideToggleModule,
     BidiModule,
   ]
 })

--- a/src/lib/popover/notification.service.ts
+++ b/src/lib/popover/notification.service.ts
@@ -41,4 +41,9 @@ export class PopoverNotificationService {
     return this.store.asObservable();
   }
 
+  /** Complete event stream. */
+  dispose(): void {
+    this.store.complete();
+  }
+
 }

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -56,6 +56,7 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit() {
+    // Anchor the popover to the element ref
     this._anchoring.anchor(this.attachedPopover, this._viewContainerRef, this._elementRef);
 
     // Re-emit open and close events
@@ -63,7 +64,6 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
       .pipe(tap(() => this.popoverOpened.emit()));
     const closed$ = this._anchoring.popoverClosed
       .pipe(tap(value => this.popoverClosed.emit(value)));
-
     merge(opened$, closed$).pipe(takeUntil(this._onDestroy)).subscribe();
   }
 

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -8,25 +8,19 @@ import {
   Output,
   ViewContainerRef
 } from '@angular/core';
-import { ESCAPE } from '@angular/cdk/keycodes';
 import { Subject } from 'rxjs/Subject';
-import { take } from 'rxjs/operators/take';
-import { takeUntil } from 'rxjs/operators/takeUntil';
-import { filter } from 'rxjs/operators/filter';
+import { merge } from 'rxjs/observable/merge';
 import { tap } from 'rxjs/operators/tap';
+import { takeUntil } from 'rxjs/operators/takeUntil';
 
 import { SatPopover } from './popover.component';
-import { NotificationAction, PopoverNotificationService } from './notification.service';
 import { getInvalidPopoverError } from './popover.errors';
 import { PopoverAnchoringService } from './popover-anchoring.service';
 
 @Directive({
   selector: '[satPopoverAnchorFor]',
   exportAs: 'satPopoverAnchor',
-  providers: [
-    PopoverNotificationService,
-    PopoverAnchoringService,
-  ],
+  providers: [PopoverAnchoringService],
 })
 export class SatPopoverAnchor implements OnInit, OnDestroy {
 
@@ -36,10 +30,7 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
   set attachedPopover(value: SatPopover) {
     // ensure that value is a popover
     this._validateAttachedPopover(value);
-    // store value and provide notification service as a communication
-    // channel between popover and anchor
     this._attachedPopover = value;
-    this._attachedPopover._notifications = this._notifications;
   }
   private _attachedPopover: SatPopover;
 
@@ -51,11 +42,8 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
 
   /** Gets whether the popover is presently open. */
   isPopoverOpen(): boolean {
-    return this._popoverOpen;
+    return this._anchoring.isPopoverOpen();
   }
-
-  /** Whether the popover is presently open. */
-  private _popoverOpen = false;
 
   /** Emits when the directive is destroyed. */
   private _onDestroy = new Subject<void>();
@@ -63,154 +51,46 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
   constructor(
     private _elementRef: ElementRef,
     private _viewContainerRef: ViewContainerRef,
-    private _notifications: PopoverNotificationService,
     public _anchoring: PopoverAnchoringService,
   ) { }
 
   ngOnInit() {
-    this._subscribeToNotifications();
-    this._validateAttachedPopover(this.attachedPopover);
+    this._anchoring.initialize(this.attachedPopover, this._viewContainerRef, this._elementRef);
+
+    // Re-emit open and close events
+    const opened$ = this._anchoring.popoverOpened
+      .pipe(tap(() => this.popoverOpened.emit()));
+    const closed$ = this._anchoring.popoverClosed
+      .pipe(tap(value => this.popoverClosed.emit(value)));
+
+    merge(opened$, closed$).pipe(takeUntil(this._onDestroy)).subscribe();
   }
 
   ngOnDestroy() {
     this._onDestroy.next();
     this._onDestroy.complete();
-    this._destroyPopover();
   }
 
   /** Toggles the popover between the open and closed states. */
   togglePopover(): void {
-    return this._popoverOpen ? this.closePopover() : this.openPopover();
+    this._anchoring.togglePopover();
   }
 
   /** Opens the popover. */
   openPopover(): void {
-    if (!this._popoverOpen) {
-      this._anchoring.createOverlay(this.attachedPopover, this._viewContainerRef, this._elementRef);
-      this._subscribeToBackdrop();
-      this._subscribeToEscape();
-      this._subscribeToDetachments();
-      this._saveOpenedState();
-    }
+    this._anchoring.openPopover();
   }
 
   /** Closes the popover. */
   closePopover(value?: any): void {
-    if (this._anchoring._overlayRef) {
-      this._saveClosedState(value);
-      this._anchoring._overlayRef.detach();
-    }
+    this._anchoring.closePopover(value);
   }
 
-  /** Removes the popover from the DOM. Does NOT update open state. */
-  private _destroyPopover(): void {
-    if (this._anchoring._overlayRef) {
-      this._anchoring._overlayRef.dispose();
-      this._anchoring._overlayRef = null;
-    }
-  }
-
-  /**
-   * Destroys the popover immediately if it is closed, or waits until it
-   * has been closed to destroy it.
-   */
-  private _destroyPopoverOnceClosed(): void {
-    if (this.isPopoverOpen() && this._anchoring._overlayRef) {
-      this._anchoring._overlayRef.detachments().pipe(
-        take(1),
-        takeUntil(this._onDestroy)
-      ).subscribe(() => this._destroyPopover());
-    } else {
-      this._destroyPopover();
-    }
-  }
-
+  // TODO: what to do with this?
   /** Throws an error if the popover instance is not provided. */
   private _validateAttachedPopover(popover: SatPopover): void {
     if (!popover || !(popover instanceof SatPopover)) {
       throw getInvalidPopoverError();
-    }
-  }
-
-  /**
-   * Call appropriate anchor method when an event is dispatched through
-   * the notification service.
-   */
-  private _subscribeToNotifications(): void {
-    this._notifications.events()
-      .pipe(takeUntil(this._onDestroy))
-      .subscribe(event => {
-        switch (event.action) {
-          case NotificationAction.OPEN:
-            this.openPopover();
-            break;
-          case NotificationAction.CLOSE:
-            this.closePopover(event.value);
-            break;
-          case NotificationAction.TOGGLE:
-            this.togglePopover();
-            break;
-          case NotificationAction.REPOSITION:
-            // TODO: When the overlay's position can be dynamically changed, do not destroy
-          case NotificationAction.UPDATE_CONFIG:
-            this._destroyPopoverOnceClosed();
-            break;
-        }
-      });
-  }
-
-  /** Close popover when backdrop is clicked. */
-  private _subscribeToBackdrop(): void {
-    this._anchoring._overlayRef
-      .backdropClick()
-      .pipe(
-        tap(() => this.attachedPopover.backdropClicked.emit()),
-        filter(() => this.attachedPopover.interactiveClose),
-        takeUntil(this.popoverClosed),
-        takeUntil(this._onDestroy),
-      )
-      .subscribe(() => this.closePopover());
-  }
-
-  /** Close popover when escape keydown event occurs. */
-  private _subscribeToEscape(): void {
-    this._anchoring._overlayRef
-      .keydownEvents()
-      .pipe(
-        tap(event => this.attachedPopover.overlayKeydown.emit(event)),
-        filter(event => event.keyCode === ESCAPE),
-        filter(() => this.attachedPopover.interactiveClose),
-        takeUntil(this.popoverClosed),
-        takeUntil(this._onDestroy),
-      )
-      .subscribe(() => this.closePopover());
-  }
-
-  /** Set state back to closed when detached. */
-  private _subscribeToDetachments(): void {
-    this._anchoring._overlayRef
-      .detachments()
-      .pipe(takeUntil(this._onDestroy))
-      .subscribe(() => this._saveClosedState());
-  }
-
-  /** Save the opened state of the popover and emit. */
-  private _saveOpenedState(): void {
-    if (!this._popoverOpen) {
-      this.attachedPopover._open = this._popoverOpen = true;
-
-      this.popoverOpened.emit();
-      this.attachedPopover.opened.emit();
-    }
-  }
-
-  /** Save the closed state of the popover and emit. */
-  private _saveClosedState(value?: any): void {
-    if (this._popoverOpen) {
-      this.attachedPopover._open = this._popoverOpen = false;
-
-      this.popoverClosed.emit(value);
-      this.attachedPopover.closed.emit(value);
     }
   }
 

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -84,7 +84,6 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
     this._anchoring.closePopover(value);
   }
 
-  // TODO: what to do with this?
   /** Throws an error if the popover instance is not provided. */
   private _validateAttachedPopover(popover: SatPopover): void {
     if (!popover || !(popover instanceof SatPopover)) {

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -30,8 +30,8 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
   set attachedPopover(value: SatPopover) {
     this._validateAttachedPopover(value);
     this._attachedPopover = value;
-    // TODO: does this need to send the new popover to the anchoring service
-    // again?
+    // Anchor the popover to the element ref
+    this._anchoring.anchor(this.attachedPopover, this._viewContainerRef, this._elementRef);
   }
   private _attachedPopover: SatPopover;
 
@@ -56,9 +56,6 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit() {
-    // Anchor the popover to the element ref
-    this._anchoring.anchor(this.attachedPopover, this._viewContainerRef, this._elementRef);
-
     // Re-emit open and close events
     const opened$ = this._anchoring.popoverOpened
       .pipe(tap(() => this.popoverOpened.emit()));

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -28,9 +28,10 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
   @Input('satPopoverAnchorFor')
   get attachedPopover() { return this._attachedPopover; }
   set attachedPopover(value: SatPopover) {
-    // ensure that value is a popover
     this._validateAttachedPopover(value);
     this._attachedPopover = value;
+    // TODO: does this need to send the new popover to the anchoring service
+    // again?
   }
   private _attachedPopover: SatPopover;
 
@@ -55,7 +56,7 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit() {
-    this._anchoring.initialize(this.attachedPopover, this._viewContainerRef, this._elementRef);
+    this._anchoring.anchor(this.attachedPopover, this._viewContainerRef, this._elementRef);
 
     // Re-emit open and close events
     const opened$ = this._anchoring.popoverOpened

--- a/src/lib/popover/popover-anchoring.service.ts
+++ b/src/lib/popover/popover-anchoring.service.ts
@@ -45,13 +45,19 @@ export class PopoverAnchoringService implements OnDestroy {
   /** Reference to the overlay containing the popover component. */
   _overlayRef: OverlayRef;
 
-  _popover: SatPopover;
-  _viewContainerRef: ViewContainerRef;
-  _anchor: ElementRef;
+  /** Reference to the target popover. */
+  private _popover: SatPopover;
+
+  /** Reference to the view container for the popover template. */
+  private _viewContainerRef: ViewContainerRef;
+
+  /** Reference to the anchor element. */
+  private _anchor: ElementRef;
 
   /** Reference to a template portal where the overlay will be attached. */
   private _portal: TemplatePortal<any>;
 
+  /** Communications channel with the popover. */
   private _notifications: PopoverNotificationService;
 
   /** Whether the popover is presently open. */
@@ -64,27 +70,30 @@ export class PopoverAnchoringService implements OnDestroy {
     private _overlay: Overlay,
     private _ngZone: NgZone,
     @Optional() private _dir: Directionality
-  ) {
-    this._notifications = new PopoverNotificationService();
-  }
+  ) { }
 
   ngOnDestroy() {
     this._onDestroy.next();
     this._onDestroy.complete();
     this._destroyPopover();
+
+    this.popoverOpened.complete();
+    this.popoverClosed.complete();
   }
 
-  initialize(popover: SatPopover, viewContainerRef: ViewContainerRef, anchor: ElementRef): void {
-    // store value and provide notification service as a communication
-    // channel between popover and anchor
+  /** Anchor a popover instance to a view and connection element. */
+  anchor(popover: SatPopover, viewContainerRef: ViewContainerRef, anchor: ElementRef): void {
     this._popover = popover;
-    this._popover._notifications = this._notifications;
-
     this._viewContainerRef = viewContainerRef;
     this._anchor = anchor;
 
-    this._subscribeToNotifications();
+    // Verify proper popover instance is provided
     this._validateAttachedPopover(this._popover);
+
+    // Provide notification service as a communication channel between popover and anchor.
+    // Then subscribe to notifications to take appropriate actions.
+    this._popover._notifications = this._notifications = new PopoverNotificationService();
+    this._subscribeToNotifications();
   }
 
   /** Gets whether the popover is presently open. */

--- a/src/lib/popover/popover-anchoring.service.ts
+++ b/src/lib/popover/popover-anchoring.service.ts
@@ -31,7 +31,6 @@ import {
   SatPopoverVerticalAlign,
   SatPopoverScrollStrategy,
 } from './popover.component';
-import { getInvalidPopoverError } from './popover.errors';
 import { PopoverNotificationService, NotificationAction } from './notification.service';
 
 /**
@@ -44,7 +43,7 @@ interface PopoverConfig {
   hasBackdrop: boolean;
   backdropClass: string;
   scrollStrategy: SatPopoverScrollStrategy;
-};
+}
 
 @Injectable()
 export class PopoverAnchoringService implements OnDestroy {
@@ -110,9 +109,6 @@ export class PopoverAnchoringService implements OnDestroy {
 
   /** Anchor a popover instance to a view and connection element. */
   anchor(popover: SatPopover, viewContainerRef: ViewContainerRef, anchor: ElementRef): void {
-    // Verify proper popover instance is provided
-    this._validateAttachedPopover(popover);
-
     // Destroy any previous popovers
     this._destroyPopover();
 
@@ -407,13 +403,6 @@ export class PopoverAnchoringService implements OnDestroy {
     strategy.withFallbackPosition({originX, originY}, {overlayX, overlayY});
   }
 
-  // TODO: what to do with this?
-  /** Throws an error if the popover instance is not provided. */
-  private _validateAttachedPopover(popover: SatPopover): void {
-    if (!popover || !(popover instanceof SatPopover)) {
-      throw getInvalidPopoverError();
-    }
-  }
 
 }
 

--- a/src/lib/popover/popover-anchoring.service.ts
+++ b/src/lib/popover/popover-anchoring.service.ts
@@ -93,8 +93,12 @@ export class PopoverAnchoringService implements OnDestroy {
 
   ngOnDestroy() {
     // Terminate subscriptions
-    this._notificationsSubscription.unsubscribe();
-    this._positionChangeSubscription.unsubscribe();
+    if (this._notificationsSubscription) {
+      this._notificationsSubscription.unsubscribe();
+    }
+    if (this._positionChangeSubscription) {
+      this._positionChangeSubscription.unsubscribe();
+    }
     this._onDestroy.next();
     this._onDestroy.complete();
 

--- a/src/lib/popover/popover-anchoring.service.ts
+++ b/src/lib/popover/popover-anchoring.service.ts
@@ -1,0 +1,282 @@
+import {
+  ElementRef,
+  Injectable,
+  NgZone,
+  OnDestroy,
+  Optional,
+  ViewContainerRef
+} from '@angular/core';
+import {
+  ConnectedPositionStrategy,
+  HorizontalConnectionPos,
+  Overlay,
+  OverlayRef,
+  OverlayConfig,
+  ScrollStrategy,
+  VerticalConnectionPos,
+} from '@angular/cdk/overlay';
+import { Directionality, Direction} from '@angular/cdk/bidi';
+import { TemplatePortal } from '@angular/cdk/portal';
+import { Subject } from 'rxjs/Subject';
+import { takeUntil } from 'rxjs/operators/takeUntil';
+
+import {
+  SatPopover,
+  SatPopoverHorizontalAlign,
+  SatPopoverVerticalAlign,
+  SatPopoverScrollStrategy,
+} from './popover.component';
+
+@Injectable()
+export class PopoverAnchoringService implements OnDestroy {
+
+  /** Reference to the overlay containing the popover component. */
+  _overlayRef: OverlayRef;
+
+  /** Reference to a template portal where the overlay will be attached. */
+  private _portal: TemplatePortal<any>;
+
+  /** Emits when the directive is destroyed. */
+  private _onDestroy = new Subject<void>();
+
+  constructor(
+    private _overlay: Overlay,
+    private _ngZone: NgZone,
+    @Optional() private _dir: Directionality
+  ) { }
+
+  ngOnDestroy() {
+    this._onDestroy.next();
+    this._onDestroy.complete();
+  }
+
+  /** Create an overlay to be attached to the portal. */
+  createOverlay(
+    popover: SatPopover,
+    viewContainerRef: ViewContainerRef,
+    anchor: ElementRef
+  ): OverlayRef {
+    if (!this._overlayRef) {
+      this._portal = new TemplatePortal(popover._templateRef, viewContainerRef);
+      const config = this._getOverlayConfig(popover, anchor);
+      this._subscribeToPositionChanges(
+        config.positionStrategy as ConnectedPositionStrategy,
+        popover
+      );
+      this._overlayRef = this._overlay.create(config);
+    }
+
+    this._overlayRef.attach(this._portal);
+    return this._overlayRef;
+  }
+
+  /** Gets the text direction of the containing app. */
+  private _getDirection(): Direction {
+    return this._dir && this._dir.value === 'rtl' ? 'rtl' : 'ltr';
+  }
+
+  /** Create and return a config for creating the overlay. */
+  private _getOverlayConfig(popover: SatPopover, anchor: ElementRef): OverlayConfig {
+    const config = new OverlayConfig({
+      positionStrategy: this._getPositionStrategy(popover, anchor),
+      hasBackdrop: popover.hasBackdrop,
+      backdropClass: popover.backdropClass || 'cdk-overlay-transparent-backdrop',
+      scrollStrategy: this._getScrollStrategyInstance(popover.scrollStrategy),
+      direction: this._getDirection(),
+    });
+
+    return config;
+  }
+
+  /**
+   * Listen to changes in the position of the overlay and set the correct alignment classes,
+   * ensuring that the animation origin is correct, even with a fallback position.
+   */
+  private _subscribeToPositionChanges(
+    position: ConnectedPositionStrategy,
+    popover: SatPopover
+  ): void {
+    position.onPositionChange
+      .pipe(takeUntil(this._onDestroy))
+      .subscribe(change => {
+        // Position changes may occur outside the Angular zone
+        this._ngZone.run(() => {
+          popover._setAlignmentClasses(
+            getHorizontalPopoverAlignment(change.connectionPair.overlayX),
+            getVerticalPopoverAlignment(change.connectionPair.overlayY),
+          );
+        });
+      });
+  }
+
+  /** Map a scroll strategy string type to an instance of a scroll strategy. */
+  private _getScrollStrategyInstance(strategy: SatPopoverScrollStrategy): ScrollStrategy {
+    switch (strategy) {
+      case 'block':
+        return this._overlay.scrollStrategies.block();
+      case 'reposition':
+        return this._overlay.scrollStrategies.reposition();
+      case 'close':
+        return this._overlay.scrollStrategies.close();
+      case 'noop':
+      default:
+        return this._overlay.scrollStrategies.noop();
+    }
+  }
+
+  /** Create and return a position strategy based on config provided to the component instance. */
+  private _getPositionStrategy(popover: SatPopover, anchor: ElementRef): ConnectedPositionStrategy {
+    const horizontalTarget = popover.horizontalAlign;
+    const verticalTarget = popover.verticalAlign;
+
+    // Attach the overlay at the preferred position
+    const {originX, overlayX} = getHorizontalConnectionPosPair(horizontalTarget);
+    const {originY, overlayY} = getVerticalConnectionPosPair(verticalTarget);
+    const strategy = this._overlay.position()
+      .connectedTo(anchor, {originX, originY}, {overlayX, overlayY})
+      .withDirection(this._getDirection());
+
+    // Add fallbacks based on the preferred positions
+    this._addFallbacks(strategy, horizontalTarget, verticalTarget);
+
+    return strategy;
+  }
+
+  /** Add fallbacks to a given strategy based around target alignments. */
+  private _addFallbacks(strategy: ConnectedPositionStrategy, hTarget: SatPopoverHorizontalAlign,
+      vTarget: SatPopoverVerticalAlign): void {
+    // Determine if the target alignments overlap the anchor
+    const horizontalOverlapAllowed = hTarget !== 'before' && hTarget !== 'after';
+    const verticalOverlapAllowed = vTarget !== 'above' && vTarget !== 'below';
+
+    // If a target alignment doesn't cover the anchor, don't let any of the fallback alignments
+    // cover the anchor
+    const possibleHorizontalAlignments = horizontalOverlapAllowed ?
+      ['before', 'start', 'center', 'end', 'after'] :
+      ['before', 'after'];
+    const possibleVerticalAlignments = verticalOverlapAllowed ?
+      ['above', 'start', 'center', 'end', 'below'] :
+      ['above', 'below'];
+
+    // Create fallbacks for each allowed prioritized fallback alignment combo
+    const fallbacks = [];
+    prioritizeAroundTarget(hTarget, possibleHorizontalAlignments).forEach(h => {
+      prioritizeAroundTarget(vTarget, possibleVerticalAlignments).forEach(v => {
+        fallbacks.push({h, v});
+      });
+    });
+
+    // Remove the first fallback since it will be the target alignment that is already applied
+    fallbacks.slice(1, fallbacks.length)
+      .forEach(({h, v}) => this._applyFallback(strategy, h, v));
+  }
+
+  /**
+  * Convert a specific horizontal and vertical alignment into a fallback and apply it to
+  * the strategy.
+  */
+  private _applyFallback(strategy, horizontalAlign, verticalAlign): void {
+    const {originX, overlayX} = getHorizontalConnectionPosPair(horizontalAlign);
+    const {originY, overlayY} = getVerticalConnectionPosPair(verticalAlign);
+    strategy.withFallbackPosition({originX, originY}, {overlayX, overlayY});
+  }
+
+}
+
+/** Helper function to convert an overlay connection position to equivalent popover alignment. */
+function getHorizontalPopoverAlignment(h: HorizontalConnectionPos): SatPopoverHorizontalAlign {
+  if (h === 'start') {
+    return 'after';
+  }
+
+  if (h === 'end') {
+    return 'before';
+  }
+
+  return 'center';
+}
+
+/** Helper function to convert an overlay connection position to equivalent popover alignment. */
+function getVerticalPopoverAlignment(v: VerticalConnectionPos): SatPopoverVerticalAlign {
+  if (v === 'top') {
+    return 'below';
+  }
+
+  if (v === 'bottom') {
+    return 'above';
+  }
+
+  return 'center';
+}
+
+/** Helper function to convert alignment to origin/overlay position pair. */
+function getHorizontalConnectionPosPair(h: SatPopoverHorizontalAlign):
+    {originX: HorizontalConnectionPos, overlayX: HorizontalConnectionPos} {
+  switch (h) {
+    case 'before':
+      return {originX: 'start', overlayX: 'end'};
+    case 'start':
+      return {originX: 'start', overlayX: 'start'};
+    case 'end':
+      return {originX: 'end', overlayX: 'end'};
+    case 'after':
+      return {originX: 'end', overlayX: 'start'};
+    default:
+      return {originX: 'center', overlayX: 'center'};
+  }
+}
+
+/** Helper function to convert alignment to origin/overlay position pair. */
+function getVerticalConnectionPosPair(v: SatPopoverVerticalAlign):
+    {originY: VerticalConnectionPos, overlayY: VerticalConnectionPos} {
+  switch (v) {
+    case 'above':
+      return {originY: 'top', overlayY: 'bottom'};
+    case 'start':
+      return {originY: 'top', overlayY: 'top'};
+    case 'end':
+      return {originY: 'bottom', overlayY: 'bottom'};
+    case 'below':
+      return {originY: 'bottom', overlayY: 'top'};
+    default:
+      return {originY: 'center', overlayY: 'center'};
+  }
+}
+
+
+/**
+ * Helper function that takes an ordered array options and returns a reorderded
+ * array around the target item. e.g.:
+ *
+ * target: 3; options: [1, 2, 3, 4, 5, 6, 7];
+ *
+ * return: [3, 4, 2, 5, 1, 6, 7]
+ */
+function prioritizeAroundTarget<T>(target: T, options: T[]): T[] {
+  const targetIndex = options.indexOf(target);
+
+  // Set the first item to be the target
+  const reordered = [target];
+
+  // Make left and right stacks where the highest priority item is last
+  const left = options.slice(0, targetIndex);
+  const right = options.slice(targetIndex + 1, options.length).reverse();
+
+  // Alternate between stacks until one is empty
+  while (left.length && right.length) {
+    reordered.push(right.pop());
+    reordered.push(left.pop());
+  }
+
+  // Flush out right side
+  while (right.length) {
+    reordered.push(right.pop());
+  }
+
+  // Flush out left side
+  while (left.length) {
+    reordered.push(left.pop());
+  }
+
+  return reordered;
+}

--- a/src/lib/popover/popover-anchoring.service.ts
+++ b/src/lib/popover/popover-anchoring.service.ts
@@ -91,6 +91,10 @@ export class PopoverAnchoringService implements OnDestroy {
   ) { }
 
   ngOnDestroy() {
+    // Destroy popover before terminating subscriptions so that any resulting
+    // detachments update 'closed state'
+    this._destroyPopover();
+
     // Terminate subscriptions
     if (this._notificationsSubscription) {
       this._notificationsSubscription.unsubscribe();
@@ -100,8 +104,6 @@ export class PopoverAnchoringService implements OnDestroy {
     }
     this._onDestroy.next();
     this._onDestroy.complete();
-
-    this._destroyPopover();
 
     this.popoverOpened.complete();
     this.popoverClosed.complete();
@@ -154,6 +156,7 @@ export class PopoverAnchoringService implements OnDestroy {
 
   /** Create an overlay to be attached to the portal. */
   createOverlay(): OverlayRef {
+    // Create overlay if it doesn't yet exist
     if (!this._overlayRef) {
       this._portal = new TemplatePortal(this._popover._templateRef, this._viewContainerRef);
 
@@ -172,6 +175,7 @@ export class PopoverAnchoringService implements OnDestroy {
       this._overlayRef = this._overlay.create(overlayConfig);
     }
 
+    // Actually open the popover
     this._overlayRef.attach(this._portal);
     return this._overlayRef;
   }

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -196,7 +196,9 @@ export class SatPopover implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this._notifications.dispose();
+    if (this._notifications) {
+      this._notifications.dispose();
+    }
   }
 
   /** Open this popover. */

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -7,6 +7,7 @@ import {
   ViewChild,
   ViewEncapsulation,
   TemplateRef,
+  OnDestroy,
   OnInit,
   Optional,
   Output,
@@ -50,7 +51,7 @@ const DEFAULT_TRANSITION  = '200ms cubic-bezier(0.25, 0.8, 0.25, 1)';
   styleUrls: ['./popover.component.scss'],
   templateUrl: './popover.component.html',
 })
-export class SatPopover implements OnInit {
+export class SatPopover implements OnInit, OnDestroy {
 
   /** Alignment of the popover on the horizontal axis. */
   @Input()
@@ -192,6 +193,10 @@ export class SatPopover implements OnInit {
 
   ngOnInit() {
     this._setAlignmentClasses();
+  }
+
+  ngOnDestroy() {
+    this._notifications.dispose();
   }
 
   /** Open this popover. */

--- a/src/lib/popover/popover.spec.ts
+++ b/src/lib/popover/popover.spec.ts
@@ -537,7 +537,7 @@ describe('SatPopover', () => {
 
       // open the overlay and store the overlayRef
       comp.popover.open();
-      const overlayAfterFirstOpen = comp.anchor._overlayRef;
+      const overlayAfterFirstOpen = comp.anchor._anchoring._overlayRef;
 
       comp.popover.close();
       fixture.detectChanges();
@@ -548,7 +548,7 @@ describe('SatPopover', () => {
       fixture.detectChanges();
 
       comp.popover.open();
-      const overlayAfterSecondOpen = comp.anchor._overlayRef;
+      const overlayAfterSecondOpen = comp.anchor._anchoring._overlayRef;
 
       expect(overlayAfterFirstOpen === overlayAfterSecondOpen).toBe(true);
     }));
@@ -558,7 +558,7 @@ describe('SatPopover', () => {
 
       // open the overlay and store the overlayRef
       comp.popover.open();
-      const overlayAfterFirstOpen = comp.anchor._overlayRef;
+      const overlayAfterFirstOpen = comp.anchor._anchoring._overlayRef;
 
       comp.popover.close();
       fixture.detectChanges();
@@ -569,7 +569,7 @@ describe('SatPopover', () => {
       fixture.detectChanges();
 
       comp.popover.open();
-      const overlayAfterSecondOpen = comp.anchor._overlayRef;
+      const overlayAfterSecondOpen = comp.anchor._anchoring._overlayRef;
 
       expect(overlayAfterFirstOpen === overlayAfterSecondOpen).toBe(false);
     }));
@@ -581,7 +581,7 @@ describe('SatPopover', () => {
 
       // centered over anchor can be any of 5 x 5 positions
       comp.popover.open();
-      overlayConfig = comp.anchor._overlayRef.getConfig();
+      overlayConfig = comp.anchor._anchoring._overlayRef.getConfig();
       strategy = overlayConfig.positionStrategy as ConnectedPositionStrategy;
       expect(strategy.positions.length).toBe(25, 'overlapping');
 
@@ -595,7 +595,7 @@ describe('SatPopover', () => {
       fixture.detectChanges();
 
       comp.popover.open();
-      overlayConfig = comp.anchor._overlayRef.getConfig();
+      overlayConfig = comp.anchor._anchoring._overlayRef.getConfig();
       strategy = overlayConfig.positionStrategy as ConnectedPositionStrategy;
       expect(strategy.positions.length).toBe(4, 'non-overlapping');
 
@@ -609,7 +609,7 @@ describe('SatPopover', () => {
       fixture.detectChanges();
 
       comp.popover.open();
-      overlayConfig = comp.anchor._overlayRef.getConfig();
+      overlayConfig = comp.anchor._anchoring._overlayRef.getConfig();
       strategy = overlayConfig.positionStrategy as ConnectedPositionStrategy;
       expect(strategy.positions.length).toBe(10, 'overlapping in one dimension');
     }));
@@ -684,7 +684,7 @@ describe('SatPopover', () => {
       fixture.detectChanges();
       comp.popover.open();
 
-      strategy = comp.anchor._overlayRef.getConfig().scrollStrategy;
+      strategy = comp.anchor._anchoring._overlayRef.getConfig().scrollStrategy;
       expect(strategy instanceof RepositionScrollStrategy).toBe(true, 'reposition strategy');
 
       comp.popover.close();
@@ -695,7 +695,7 @@ describe('SatPopover', () => {
       fixture.detectChanges();
       comp.popover.open();
 
-      strategy = comp.anchor._overlayRef.getConfig().scrollStrategy;
+      strategy = comp.anchor._anchoring._overlayRef.getConfig().scrollStrategy;
       expect(strategy instanceof BlockScrollStrategy).toBe(true, 'block strategy');
     }));
 
@@ -705,7 +705,7 @@ describe('SatPopover', () => {
       comp.popover.open();
 
       // expect it to be open with default strategy
-      strategy = comp.anchor._overlayRef.getConfig().scrollStrategy;
+      strategy = comp.anchor._anchoring._overlayRef.getConfig().scrollStrategy;
       expect(strategy instanceof RepositionScrollStrategy).toBe(true, 'reposition strategy');
       expect(overlayContainerElement.textContent).toContain('Popover', 'initially open');
 
@@ -715,7 +715,7 @@ describe('SatPopover', () => {
       tick();
 
       // expect it to have remained open with default strategy
-      strategy = comp.anchor._overlayRef.getConfig().scrollStrategy;
+      strategy = comp.anchor._anchoring._overlayRef.getConfig().scrollStrategy;
       expect(strategy instanceof RepositionScrollStrategy).toBe(true, 'still reposition strategy');
       expect(overlayContainerElement.textContent).toContain('Popover', 'Still open');
 
@@ -726,7 +726,7 @@ describe('SatPopover', () => {
       comp.popover.open();
 
       // expect the new strategy to be in place
-      strategy = comp.anchor._overlayRef.getConfig().scrollStrategy;
+      strategy = comp.anchor._anchoring._overlayRef.getConfig().scrollStrategy;
       expect(strategy instanceof BlockScrollStrategy).toBe(true, 'block strategy');
     }));
 


### PR DESCRIPTION


- Use helper anchoring service to offload overlay management logic from the anchor directive
- Complete notifications stream when popover is destroyed
- Unsubscribe from internal position changes subscription before resubscribing
- Add toggle to demo app that destroys all components (for checking destroy errors)
- Add demo that can toggle which of two popovers is attached to an anchor
  

This is in preparation of allowing popovers to be anchored to any element via a service (part of #23).