### PR TITLE
feat: expose anchoring service

### DIFF
--- a/src/demo/app/anchor-reuse/anchor-reuse.component.scss
+++ b/src/demo/app/anchor-reuse/anchor-reuse.component.scss
@@ -1,3 +1,7 @@
+:host {
+  display: block;
+}
+
 .wrapper {
   background: black;
   color: white;

--- a/src/demo/app/demo.component.ts
+++ b/src/demo/app/demo.component.ts
@@ -31,6 +31,7 @@ import { Component } from '@angular/core';
       <demo-tooltip></demo-tooltip>
       <demo-interactive-close></demo-interactive-close>
       <demo-anchor-reuse></demo-anchor-reuse>
+      <demo-event-delegation></demo-event-delegation>
       <demo-speed-dial></demo-speed-dial>
     </div>
   `

--- a/src/demo/app/demo.module.ts
+++ b/src/demo/app/demo.module.ts
@@ -15,6 +15,7 @@ import {
   MatNativeDateModule,
   MatRadioModule,
   MatSlideToggleModule,
+  MatTableModule,
 } from '@angular/material';
 import { BidiModule } from '@angular/cdk/bidi';
 
@@ -29,6 +30,7 @@ import { TooltipDemo } from './tooltip/tooltip.component';
 import { SpeedDialDemo } from './speed-dial/speed-dial.component';
 import { InteractiveCloseDemo } from './interactive-close/interactive-close.component';
 import { AnchorReuseComponent } from './anchor-reuse/anchor-reuse.component';
+import { EventDelegationDemo } from './event-delegation/event-delegation.component';
 
 @NgModule({
   exports: [
@@ -43,6 +45,7 @@ import { AnchorReuseComponent } from './anchor-reuse/anchor-reuse.component';
     MatNativeDateModule,
     MatRadioModule,
     MatSlideToggleModule,
+    MatTableModule,
     BidiModule,
   ]
 })
@@ -61,6 +64,7 @@ export class DemoMaterialModule { }
     SpeedDialDemo,
     InteractiveCloseDemo,
     AnchorReuseComponent,
+    EventDelegationDemo,
   ],
   imports: [
     BrowserModule,

--- a/src/demo/app/event-delegation/event-delegation.component.scss
+++ b/src/demo/app/event-delegation/event-delegation.component.scss
@@ -1,0 +1,22 @@
+@import '~@angular/material/theming';
+
+:host {
+  display: block;
+}
+
+.mat-table {
+  overflow: auto;
+  max-height: 200px;
+}
+
+.view-popover {
+  @include mat-elevation(4);
+  background: white;
+  padding: 16px;
+}
+
+.remove-popover {
+  @include mat-elevation(4);
+  background: white;
+  padding: 16px;
+}

--- a/src/demo/app/event-delegation/event-delegation.component.ts
+++ b/src/demo/app/event-delegation/event-delegation.component.ts
@@ -1,0 +1,160 @@
+import { Component, ElementRef, ViewChild, ViewContainerRef } from '@angular/core';
+import { MatTableDataSource } from '@angular/material';
+import { SatPopover, SatPopoverAnchoringService } from '@ncstate/sat-popover';
+
+@Component({
+  selector: 'demo-event-delegation',
+  styleUrls: ['./event-delegation.component.scss'],
+  providers: [
+    SatPopoverAnchoringService
+  ],
+  template: `
+    <mat-card>
+      <mat-card-title>Anchor via Event Delegation</mat-card-title>
+      <mat-card-content>
+
+        <div class="mat-elevation-z4">
+          <mat-table #table [dataSource]="dataSource" (click)="delegateTableClick($event)">
+
+            <!-- Position Column -->
+            <ng-container matColumnDef="position">
+              <mat-header-cell *matHeaderCellDef> No. </mat-header-cell>
+              <mat-cell *matCellDef="let element"> {{element.position}} </mat-cell>
+            </ng-container>
+
+            <!-- Name Column -->
+            <ng-container matColumnDef="name">
+              <mat-header-cell *matHeaderCellDef> Name </mat-header-cell>
+              <mat-cell *matCellDef="let element"> {{element.name}} </mat-cell>
+            </ng-container>
+
+            <!-- Symbol Column -->
+            <ng-container matColumnDef="symbol">
+              <mat-header-cell *matHeaderCellDef> Symbol </mat-header-cell>
+              <mat-cell *matCellDef="let element"> {{element.symbol}} </mat-cell>
+            </ng-container>
+
+            <!-- Actions Column -->
+            <ng-container matColumnDef="actions">
+              <mat-header-cell *matHeaderCellDef></mat-header-cell>
+              <mat-cell *matCellDef="let element">
+                <button data-action="view" [attr.data-id]="element.position">
+                  View
+                </button>
+                <button data-action="remove" [attr.data-id]="element.position">
+                  Remove
+                </button>
+              </mat-cell>
+            </ng-container>
+
+            <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+            <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+          </mat-table>
+        </div>
+
+      </mat-card-content>
+    </mat-card>
+
+    <sat-popover #view hasBackdrop backdropClass="demo-background-dark">
+      <div class="view-popover">
+        <ng-container *ngIf="getActiveElement(); let element">
+          <b>{{ element.name }}</b><br>Weight: {{ element.weight }}
+        </ng-container>
+      </div>
+    </sat-popover>
+
+    <sat-popover #remove hasBackdrop backdropClass="demo-background-dark">
+      <div class="remove-popover">
+        Are you sure?<br>
+        <button (click)="remove.close()">No</button>
+        <button (click)="deleteRow(activeRow); remove.close()">Yes</button>
+      </div>
+    </sat-popover>
+  `
+})
+export class EventDelegationDemo {
+
+  @ViewChild('view') viewPopover: SatPopover;
+  @ViewChild('remove') removePopover: SatPopover;
+
+  displayedColumns = ['position', 'name', 'symbol', 'actions'];
+  dataSource = new MatTableDataSource<Element>(ELEMENT_DATA);
+  activeRow: number;
+
+  constructor(
+    private anchoringService: SatPopoverAnchoringService,
+    private viewContainerRef: ViewContainerRef,
+  ) { }
+
+  getActiveElement(): Element {
+    return this.dataSource.data.find(row => row.position === this.activeRow);
+  }
+
+  delegateTableClick(event): void {
+    if (event.target.matches('.mat-cell.mat-column-actions button')) {
+      const action = event.target.getAttribute('data-action');
+      const id = event.target.getAttribute('data-id');
+
+      if (action === 'view') {
+        this.view(+id, event.target);
+      } else if (action === 'remove') {
+        this.remove(+id, event.target);
+      }
+    }
+  }
+
+  view(id: number, element: any): void {
+    this.activeRow = id;
+    this.anchoringService.anchor(this.viewPopover, this.viewContainerRef, new ElementRef(element));
+    this.anchoringService.openPopover();
+  }
+
+  remove(id: number, element: any): void {
+    this.activeRow = id;
+    this.anchoringService.anchor(
+      this.removePopover,
+      this.viewContainerRef,
+      new ElementRef(element)
+    );
+    this.anchoringService.openPopover();
+  }
+
+  deleteRow(id): void {
+    const rows = this.dataSource.data.slice();
+    const index = rows.findIndex(row => row.position === id);
+    if (index > -1) {
+      rows.splice(index, 1);
+    }
+    this.dataSource.data = rows;
+  }
+}
+
+export interface Element {
+  name: string;
+  position: number;
+  weight: number;
+  symbol: string;
+}
+
+const ELEMENT_DATA: Element[] = [
+  {position: 1, name: 'Hydrogen', weight: 1.0079, symbol: 'H'},
+  {position: 2, name: 'Helium', weight: 4.0026, symbol: 'He'},
+  {position: 3, name: 'Lithium', weight: 6.941, symbol: 'Li'},
+  {position: 4, name: 'Beryllium', weight: 9.0122, symbol: 'Be'},
+  {position: 5, name: 'Boron', weight: 10.811, symbol: 'B'},
+  {position: 6, name: 'Carbon', weight: 12.0107, symbol: 'C'},
+  {position: 7, name: 'Nitrogen', weight: 14.0067, symbol: 'N'},
+  {position: 8, name: 'Oxygen', weight: 15.9994, symbol: 'O'},
+  {position: 9, name: 'Fluorine', weight: 18.9984, symbol: 'F'},
+  {position: 10, name: 'Neon', weight: 20.1797, symbol: 'Ne'},
+  {position: 11, name: 'Sodium', weight: 22.9897, symbol: 'Na'},
+  {position: 12, name: 'Magnesium', weight: 24.305, symbol: 'Mg'},
+  {position: 13, name: 'Aluminum', weight: 26.9815, symbol: 'Al'},
+  {position: 14, name: 'Silicon', weight: 28.0855, symbol: 'Si'},
+  {position: 15, name: 'Phosphorus', weight: 30.9738, symbol: 'P'},
+  {position: 16, name: 'Sulfur', weight: 32.065, symbol: 'S'},
+  {position: 17, name: 'Chlorine', weight: 35.453, symbol: 'Cl'},
+  {position: 18, name: 'Argon', weight: 39.948, symbol: 'Ar'},
+  {position: 19, name: 'Potassium', weight: 39.0983, symbol: 'K'},
+  {position: 20, name: 'Calcium', weight: 40.078, symbol: 'Ca'},
+];

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -15,12 +15,12 @@ import { takeUntil } from 'rxjs/operators/takeUntil';
 
 import { SatPopover } from './popover.component';
 import { getInvalidPopoverError } from './popover.errors';
-import { PopoverAnchoringService } from './popover-anchoring.service';
+import { SatPopoverAnchoringService } from './popover-anchoring.service';
 
 @Directive({
   selector: '[satPopoverAnchorFor]',
   exportAs: 'satPopoverAnchor',
-  providers: [PopoverAnchoringService],
+  providers: [SatPopoverAnchoringService],
 })
 export class SatPopoverAnchor implements OnInit, OnDestroy {
 
@@ -52,7 +52,7 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
   constructor(
     private _elementRef: ElementRef,
     private _viewContainerRef: ViewContainerRef,
-    public _anchoring: PopoverAnchoringService,
+    public _anchoring: SatPopoverAnchoringService,
   ) { }
 
   ngOnInit() {

--- a/src/lib/popover/popover-anchoring.service.ts
+++ b/src/lib/popover/popover-anchoring.service.ts
@@ -46,7 +46,7 @@ interface PopoverConfig {
 }
 
 @Injectable()
-export class PopoverAnchoringService implements OnDestroy {
+export class SatPopoverAnchoringService implements OnDestroy {
 
   /** Emits when the popover is opened. */
   popoverOpened = new Subject<void>();
@@ -155,7 +155,7 @@ export class PopoverAnchoringService implements OnDestroy {
   }
 
   /** Create an overlay to be attached to the portal. */
-  createOverlay(): OverlayRef {
+  private createOverlay(): OverlayRef {
     // Create overlay if it doesn't yet exist
     if (!this._overlayRef) {
       this._portal = new TemplatePortal(this._popover._templateRef, this._viewContainerRef);

--- a/src/lib/public_api.ts
+++ b/src/lib/public_api.ts
@@ -6,3 +6,4 @@ export {
   SatPopoverVerticalAlign,
   SatPopoverScrollStrategy,
 } from './popover/popover.component';
+export { SatPopoverAnchoringService } from './popover/popover-anchoring.service';


### PR DESCRIPTION
Partially addresses #23

This also adds a demo to show using the same 2 popover instances to anchor to a variety of buttons via event delegation on the table rows. It looks like this:

![event-delegation-example](https://user-images.githubusercontent.com/6475576/34744122-2662da22-f55a-11e7-9775-8644335605a8.gif)

@rosslavery: I'm interested in your feedback here. I'm not totally sold on the naming or whether I should wrap `SatPopoverAnchoringService` in another service with a better api, but I think this accomplishes what you were discussing in #23 pretty well. 

...in fact, as I'm typing this, I believe this does deserve a wrapper service due to how clunky it is to simultaneously open multiple popovers (`SatPopoverAnchoringService` only supports one popover-anchor pair at a time).