### PR TITLE
chore: bump to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-# 3.3.0 vigorous-tigress
+# 4.0.0 quarrel-squirrel
+
+### Breaking Changes (aka Features)
+* Peer dependencies of `@angular/{core,common,cdk}` are now set to `^8.0.0`.
+* Dynamic Anchors are now available. See README for more information on this breaking change.
+* No significant changes from v3.3.0, just bumping version via `semver` protocol.
+
+# 3.3.0 vigorous-tigress (obsoleted with v4.0.0)
 
 ### Breaking Changes (aka Features)
 * Peer dependencies of `@angular/{core,common,cdk}` are now set to `^8.0.0`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ncstate/sat-popover",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ncstate/sat-popover",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf dist",


### PR DESCRIPTION
Bumping version to v4.0.0 via https://github.com/ncstate-sat/popover/wiki/releases