### PR TITLE
feat: make scale values for animation customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,16 @@ You can modify these animation curves using `openTransition` and `closeTransitio
 </sat-popover>
 ```
 
+Additionally you can modify the scale values for the opening (`startAtScale`) and closing (`endAtScale`) animations.
+```html
+<!-- very subtle scale animation -->
+<sat-popover #mySubtlePopover
+    openAnimationStartAtScale="0.95"
+    closeAnimationEndAtScale="0.95">
+  <!-- ... -->
+</sat-popover>
+```
+
 ## Styles
 
 The `<sat-popover>` component only provides styles to affect its own transform origin. It is

--- a/src/demo/app/transitions/transitions.component.ts
+++ b/src/demo/app/transitions/transitions.component.ts
@@ -14,6 +14,14 @@ import { Component } from '@angular/core';
           <mat-form-field>
             <input matInput type="text" [(ngModel)]="closeTransition" />
           </mat-form-field>
+          <mat-form-field>
+            <input matInput type="number" [(ngModel)]="startAtScale" />
+            <mat-hint>Initial scale value for open animation.</mat-hint>
+          </mat-form-field>
+          <mat-form-field>
+            <input matInput type="number" [(ngModel)]="endAtScale" />
+            <mat-hint>End scale value for close animation.</mat-hint>
+          </mat-form-field>
         </div>
 
         <div class="indicators">
@@ -31,6 +39,8 @@ import { Component } from '@angular/core';
           [anchor]="popoverAnchor"
           [openTransition]="openTransition"
           [closeTransition]="closeTransition"
+          [openAnimationStartAtScale]="startAtScale"
+          [closeAnimationEndAtScale]="endAtScale"
           (opened)="showCallback('opened')"
           (closed)="showCallback('closed')"
           (afterOpen)="showCallback('afterOpen')"
@@ -45,6 +55,8 @@ import { Component } from '@angular/core';
 export class TransitionsDemo {
   openTransition = '2000ms ease';
   closeTransition = '2000ms ease';
+  startAtScale = 0.3;
+  endAtScale = 0.5;
 
   callbackIndicators = [
     { name: 'opened', active: false },

--- a/src/lib/popover/popover.animations.ts
+++ b/src/lib/popover/popover.animations.ts
@@ -9,12 +9,12 @@ import {
 
 export const transformPopover: AnimationTriggerMetadata = trigger('transformPopover', [
   transition(':enter', [
-    style({opacity: 0, transform: 'scale(0.3)'}),
+    style({opacity: 0, transform: 'scale({{startAtScale}})'}),
     animate('{{openTransition}}',
       style({opacity: 1, transform: 'scale(1)'}))
   ]),
   transition(':leave', [
     animate('{{closeTransition}}',
-      style({opacity: 0, transform: 'scale(0.5)'}))
+      style({opacity: 0, transform: 'scale({{endAtScale}})'}))
   ])
 ]);

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -17,7 +17,7 @@ import {
 import { AnimationEvent } from '@angular/animations';
 import { DOCUMENT } from '@angular/common';
 import { FocusTrap, FocusTrapFactory } from '@angular/cdk/a11y';
-import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
 
 import { transformPopover } from './popover.animations';
 import {
@@ -42,6 +42,8 @@ import { SatPopoverAnchoringService } from './popover-anchoring.service';
 
 // See http://cubic-bezier.com/#.25,.8,.25,1 for reference.
 const DEFAULT_TRANSITION = '200ms cubic-bezier(0.25, 0.8, 0.25, 1)';
+const DEFAULT_OPEN_ANIMATION_START_SCALE = 0.3;
+const DEFAULT_CLOSE_ANIMATION_END_SCALE = 0.5;
 
 @Directive({
   selector: '[satPopoverAnchor]',
@@ -261,6 +263,32 @@ export class SatPopover implements OnInit {
   }
   private _closeTransition = DEFAULT_TRANSITION;
 
+  /** Scale value at the start of the :enter animation. */
+  @Input()
+  get openAnimationStartAtScale() {
+    return this._openAnimationStartAtScale;
+  }
+  set openAnimationStartAtScale(val: number) {
+    const coercedVal = coerceNumberProperty(val);
+    if (!isNaN(coercedVal)) {
+      this._openAnimationStartAtScale = val;
+    }
+  }
+  private _openAnimationStartAtScale = DEFAULT_OPEN_ANIMATION_START_SCALE;
+
+  /** Scale value at the end of the :leave animation */
+  @Input()
+  get closeAnimationEndAtScale() {
+    return this._closeAnimationEndAtScale;
+  }
+  set closeAnimationEndAtScale(val: number) {
+    const coercedVal = coerceNumberProperty(val);
+    if (!isNaN(coercedVal)) {
+      this._closeAnimationEndAtScale = val;
+    }
+  }
+  private _closeAnimationEndAtScale = DEFAULT_CLOSE_ANIMATION_END_SCALE;
+
   /** Optional backdrop class. */
   @Input() backdropClass = '';
 
@@ -359,7 +387,12 @@ export class SatPopover implements OnInit {
   _getAnimation(): { value: any; params: any } {
     return {
       value: 'visible',
-      params: { openTransition: this.openTransition, closeTransition: this.closeTransition }
+      params: {
+        openTransition: this.openTransition,
+        closeTransition: this.closeTransition,
+        startAtScale: this.openAnimationStartAtScale,
+        endAtScale: this.closeAnimationEndAtScale
+      }
     };
   }
 


### PR DESCRIPTION
While I can see how we can't easily get issue https://github.com/ncstate-sat/popover/issues/114 resolved, I would love to be able to at least change the relevant scale values inside the AnimationTriggerMetadata.

- Tests are green
- Updated README and demo application

Currently I am setting the open and close Transition to `0ms` and using pure CSS animations on a custom popover container :/