### PR TITLE
fix: demo build was not building

### DIFF
--- a/src/demo/tsconfig.app.json
+++ b/src/demo/tsconfig.app.json
@@ -2,13 +2,13 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/app",
+    "importHelpers": true,
+
     "types": []
   },
-  "files": [
-    "main.ts",
-    "polyfills.ts"
-  ],
-  "include": [
-    "src/demo/**/*.d.ts"
-  ]
+  "angularCompilerOptions": {
+    "enableIvy": false
+  },
+  "files": ["main.ts", "polyfills.ts"],
+  "include": ["src/demo/**/*.d.ts"]
 }


### PR DESCRIPTION
Recent upgrades caused the demo build to not build.

```bash
rm -rf node_modules package-lock.json dist
npm i
npm run build
npm run build:demo
```

all good now.