### PR TITLE
boolean inputs are now BooleanInput (number same)

### DIFF
--- a/src/lib/popover/popover-anchoring.service.ts
+++ b/src/lib/popover/popover-anchoring.service.ts
@@ -12,6 +12,7 @@ import {
 import { Directionality, Direction } from '@angular/cdk/bidi';
 import { ESCAPE } from '@angular/cdk/keycodes';
 import { TemplatePortal } from '@angular/cdk/portal';
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { Subscription, Subject } from 'rxjs';
 import { takeUntil, take, filter, tap } from 'rxjs/operators';
 
@@ -190,11 +191,11 @@ export class SatPopoverAnchoringService implements OnDestroy {
       const popoverConfig: PopoverConfig = {
         horizontalAlign: this._popover.horizontalAlign,
         verticalAlign: this._popover.verticalAlign,
-        hasBackdrop: this._popover.hasBackdrop,
+        hasBackdrop: coerceBooleanProperty(this._popover.hasBackdrop),
         backdropClass: this._popover.backdropClass,
         scrollStrategy: this._popover.scrollStrategy,
-        forceAlignment: this._popover.forceAlignment,
-        lockAlignment: this._popover.lockAlignment,
+        forceAlignment: coerceBooleanProperty(this._popover.forceAlignment),
+        lockAlignment: coerceBooleanProperty(this._popover.lockAlignment),
         panelClass: this._popover.panelClass
       };
 

--- a/src/lib/popover/popover-hover.directive.ts
+++ b/src/lib/popover/popover-hover.directive.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Directive, HostListener, Input, OnDestroy } from '@angular/core';
-import { coerceNumberProperty } from '@angular/cdk/coercion';
+import { coerceNumberProperty, NumberInput } from '@angular/cdk/coercion';
 import { of, Subject } from 'rxjs';
 import { delay, switchMap, takeUntil } from 'rxjs/operators';
 
@@ -17,7 +17,7 @@ export class SatPopoverHoverDirective implements AfterViewInit, OnDestroy {
   get satPopoverHover() {
     return this._satPopoverHover;
   }
-  set satPopoverHover(val: number) {
+  set satPopoverHover(val: NumberInput) {
     this._satPopoverHover = coerceNumberProperty(val);
   }
   private _satPopoverHover = 0;

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -17,7 +17,7 @@ import {
 import { AnimationEvent } from '@angular/animations';
 import { DOCUMENT } from '@angular/common';
 import { ConfigurableFocusTrap, ConfigurableFocusTrapFactory, FocusTrap, FocusTrapFactory } from '@angular/cdk/a11y';
-import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
+import { BooleanInput, coerceBooleanProperty, coerceNumberProperty, NumberInput } from '@angular/cdk/coercion';
 
 import { transformPopover } from './popover.animations';
 import {
@@ -156,7 +156,7 @@ export class SatPopover implements OnInit {
   get forceAlignment() {
     return this._forceAlignment;
   }
-  set forceAlignment(val: boolean) {
+  set forceAlignment(val: BooleanInput) {
     const coercedVal = coerceBooleanProperty(val);
     if (this._forceAlignment !== coercedVal) {
       this._forceAlignment = coercedVal;
@@ -173,7 +173,7 @@ export class SatPopover implements OnInit {
   get lockAlignment() {
     return this._lockAlignment;
   }
-  set lockAlignment(val: boolean) {
+  set lockAlignment(val: BooleanInput) {
     const coercedVal = coerceBooleanProperty(val);
     if (this._lockAlignment !== coercedVal) {
       this._lockAlignment = coerceBooleanProperty(val);
@@ -187,7 +187,7 @@ export class SatPopover implements OnInit {
   get autoFocus() {
     return this._autoFocus && this._autoFocusOverride;
   }
-  set autoFocus(val: boolean) {
+  set autoFocus(val: BooleanInput) {
     this._autoFocus = coerceBooleanProperty(val);
   }
   private _autoFocus = true;
@@ -198,7 +198,7 @@ export class SatPopover implements OnInit {
   get restoreFocus() {
     return this._restoreFocus && this._restoreFocusOverride;
   }
-  set restoreFocus(val: boolean) {
+  set restoreFocus(val: BooleanInput) {
     this._restoreFocus = coerceBooleanProperty(val);
   }
   private _restoreFocus = true;
@@ -223,7 +223,7 @@ export class SatPopover implements OnInit {
   get hasBackdrop() {
     return this._hasBackdrop;
   }
-  set hasBackdrop(val: boolean) {
+  set hasBackdrop(val: BooleanInput) {
     this._hasBackdrop = coerceBooleanProperty(val);
   }
   private _hasBackdrop = false;
@@ -233,7 +233,7 @@ export class SatPopover implements OnInit {
   get interactiveClose() {
     return this._interactiveClose;
   }
-  set interactiveClose(val: boolean) {
+  set interactiveClose(val: BooleanInput) {
     this._interactiveClose = coerceBooleanProperty(val);
   }
   private _interactiveClose = true;
@@ -267,10 +267,10 @@ export class SatPopover implements OnInit {
   get openAnimationStartAtScale() {
     return this._openAnimationStartAtScale;
   }
-  set openAnimationStartAtScale(val: number) {
+  set openAnimationStartAtScale(val: NumberInput) {
     const coercedVal = coerceNumberProperty(val);
     if (!isNaN(coercedVal)) {
-      this._openAnimationStartAtScale = val;
+      this._openAnimationStartAtScale = coercedVal;
     }
   }
   private _openAnimationStartAtScale = DEFAULT_OPEN_ANIMATION_START_SCALE;
@@ -280,10 +280,10 @@ export class SatPopover implements OnInit {
   get closeAnimationEndAtScale() {
     return this._closeAnimationEndAtScale;
   }
-  set closeAnimationEndAtScale(val: number) {
+  set closeAnimationEndAtScale(val: NumberInput) {
     const coercedVal = coerceNumberProperty(val);
     if (!isNaN(coercedVal)) {
-      this._closeAnimationEndAtScale = val;
+      this._closeAnimationEndAtScale = coercedVal;
     }
   }
   private _closeAnimationEndAtScale = DEFAULT_CLOSE_ANIMATION_END_SCALE;


### PR DESCRIPTION
When using sat-popover in strict mode, you can't use the boolean inputs without passing a boolean value. 
Doing that causes an error, because basically it's equivalent of passing an empty string into a boolean input.

Angular cdk has a simple solution for that: using inputs of type BooleanInput or NumberInput, that also accept strings.