### PR TITLE
chore: fix npm account for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 13.0.2 submarine-plumbing
+
+### Breaking Changes
+
+- None
+
+### Notes
+
+- Correcting the npm account for the latest release
+
 ## 13.0.1 plain-plane
 
 ### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ncstate/sat-popover",
-  "version": "13.0.1",
+  "version": "13.0.2",
   "license": "MIT",
   "engines": {
     "npm": ">=10.0.0",


### PR DESCRIPTION
I have phased out an older npm account in favor of a new one. However apparently the last release used the old one. This release has no functional changes.