### PR TITLE
Update CHANGELOG for 8.0.0: Angular v11 -> Angular v12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,7 +272,7 @@ Tagging got screwed up. 10.2.2 is good.
 
 ### Breaking Changes (aka Features)
 
-- Peer dependencies of `@angular/{core,common,cdk}` are now set to `^11.0.0`.
+- Peer dependencies of `@angular/{core,common,cdk}` are now set to `^12.1.3`.
 
 ### Fixes
 


### PR DESCRIPTION
Updated CHANGELOG for Angular v 8.0.0 to show that it is only compatible with version ^12.1.3.