### PR TITLE
feat(demo): add spin animations to speed-dial component

### DIFF
--- a/.changeset/vast-eyes-lead.md
+++ b/.changeset/vast-eyes-lead.md
@@ -1,0 +1,5 @@
+---
+'@ncstate/sat-popover': minor
+---
+
+Update the demo speed-dial component to remove deprecations

--- a/src/demo/app/speed-dial/speed-dial.component.scss
+++ b/src/demo/app/speed-dial/speed-dial.component.scss
@@ -35,3 +35,34 @@
   margin: 8px;
   font-size: 12px;
 }
+
+/* New enter/leave animations */
+.spin-enter {
+  animation: spin-enter 150ms ease;
+}
+
+@keyframes spin-enter {
+  from {
+    transform: rotate(-180deg);
+    opacity: 0;
+  }
+  to {
+    transform: rotate(0);
+    opacity: 1;
+  }
+}
+
+.spin-leave {
+  animation: spin-leave 150ms ease;
+}
+
+@keyframes spin-leave {
+  from {
+    transform: rotate(0);
+    opacity: 1;
+  }
+  to {
+    transform: rotate(180deg);
+    opacity: 0;
+  }
+}

--- a/src/demo/app/speed-dial/speed-dial.component.ts
+++ b/src/demo/app/speed-dial/speed-dial.component.ts
@@ -3,20 +3,11 @@ import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { SatPopoverModule } from '../../../lib/public_api';
-import { trigger, state, style, animate, transition, query } from '@angular/animations';
 
 @Component({
   imports: [FormsModule, MatButtonModule, MatIconModule, SatPopoverModule],
   selector: 'demo-speed-dial',
   styleUrls: ['./speed-dial.component.scss'],
-  animations: [
-    trigger('spinInOut', [
-      state('in', style({ transform: 'rotate(0)', opacity: '1' })),
-      transition(':enter', [style({ transform: 'rotate(-180deg)', opacity: '0' }), animate('150ms ease')]),
-      transition(':leave', [animate('150ms ease', style({ transform: 'rotate(180deg)', opacity: '0' }))])
-    ]),
-    trigger('preventInitialAnimation', [transition(':enter', [query(':enter', [], { optional: true })])])
-  ],
   template: `
     <!-- Fab -->
     <button
@@ -24,13 +15,12 @@ import { trigger, state, style, animate, transition, query } from '@angular/anim
       satPopoverAnchor
       #dialAnchor="satPopoverAnchor"
       color="primary"
-      [@preventInitialAnimation]
       (click)="dialPopover.toggle()"
     >
       @if (dialPopover.isOpen()) {
-        <mat-icon [@spinInOut]="'in'">close</mat-icon>
+        <mat-icon animate.enter="spin-enter" animate.leave="spin-leave">close</mat-icon>
       } @else {
-        <mat-icon [@spinInOut]="'in'">edit</mat-icon>
+        <mat-icon animate.enter="spin-enter" animate.leave="spin-leave">edit</mat-icon>
       }
     </button>
 


### PR DESCRIPTION
Refactor the speed-dial demo to use CSS-based animations instead of Angular component animations for enter/leave transitions. This includes adding keyframe animations for spinning effects in the component's SCSS file.