### PR TITLE
fix(deploy): update deploy workflow and clean up unused files

### DIFF
--- a/.changeset/salty-squids-hang.md
+++ b/.changeset/salty-squids-hang.md
@@ -1,0 +1,5 @@
+---
+'@ncstate/sat-popover': minor
+---
+
+Fix to GitHub Pages workflow, again

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -26,10 +26,10 @@ jobs:
         run: npm ci
 
       - name: Build the project
-        run: npm run build
+        run: npm run build:demo
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist/demo
+          publish_dir: ./dist/demo/browser

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,0 @@
-<!-- index.html -->
-<!DOCTYPE html>
-<html>
-<head><title>Popover Demo</title></head>
-<body><h1>Hello from GitHub Pages!</h1></body>
-</html>

--- a/tools/constants.ts
+++ b/tools/constants.ts
@@ -8,11 +8,9 @@ const __dirname = dirname(__filename);
 // paths
 export const SOURCE_PACKAGE_PATH = join(__dirname, '..', 'package.json');
 export const SOURCE_README_PATH = join(__dirname, '..', 'README.md');
-export const SOURCE_INDEX_PATH = join(__dirname, '..', 'public', 'index.html');
 export const DIST_PATH = join(__dirname, '..', 'dist', 'popover');
 export const DIST_PACKAGE_PATH = join(DIST_PATH, 'package.json');
 export const DIST_README_PATH = join(DIST_PATH, 'README.md');
-export const DIST_INDEX_PATH = join(DIST_PATH, 'index.html');
 
 // config
 export const PEER_DEPENDENCIES = ['@angular/common', '@angular/core', '@angular/cdk'];

--- a/tools/prepare-package.ts
+++ b/tools/prepare-package.ts
@@ -6,9 +6,7 @@ import {
   PEER_DEPENDENCIES,
   PACKAGE_PROPERTIES,
   DIST_README_PATH,
-  SOURCE_README_PATH,
-  SOURCE_INDEX_PATH,
-  DIST_INDEX_PATH
+  SOURCE_README_PATH
 } from './constants';
 
 interface PackageData {
@@ -19,7 +17,8 @@ interface PackageData {
 
 /** Pull required data from the source package.json. */
 function getSourceData(dependencyKeys: string[], propertyKeys: string[]): PackageData {
-  const pick = (obj: { [x: string]: any; }, props: any[]) => Object.assign({}, ...props.map((prop) => ({ [prop]: obj[prop] })));
+  const pick = (obj: { [x: string]: any }, props: any[]) =>
+    Object.assign({}, ...props.map((prop) => ({ [prop]: obj[prop] })));
   const src = JSON.parse(readFileSync(SOURCE_PACKAGE_PATH, 'utf8'));
 
   // package version
@@ -64,12 +63,5 @@ function copyReadme(): void {
   return copyFileSync(SOURCE_README_PATH, DIST_README_PATH);
 }
 
-/** Copy index.html to dist. */
-function copyIndexHtml(): void {
-  console.log(pc.cyan('Copying public/index.html to dist package'));
-  return copyFileSync(SOURCE_INDEX_PATH, DIST_INDEX_PATH);
-}
-
 replacePackageValues();
 copyReadme();
-copyIndexHtml();


### PR DESCRIPTION
- Bump actions/checkout to v5
- Update build command from `build` to `build:demo`
- Update publish directory to `./dist/demo/browser`
- Remove public/index.html as it's no longer needed
- Refactor constants.ts by removing unused exports
- Remove copyIndexHtml function from prepare-package.ts

BREAKING CHANGE: This update changes the build and deployment process. Ensure that any scripts or configurations relying on the old workflow are updated accordingly.